### PR TITLE
Neuer Testfall fertig, schedule action nur einmal die Stunde

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,7 @@ name: Playwright Tests
 on:
   workflow_dispatch:
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,7 +1,7 @@
 name: Scheduled Playwright Tests
 on:
   schedule:
-    - cron: '* 6 * * *'
+    - cron: '10 6 * * *'
 jobs:
   test:
     timeout-minutes: 60

--- a/pages/login.page.ts
+++ b/pages/login.page.ts
@@ -2,23 +2,24 @@ import { expect, type Locator, Page } from '@playwright/test';
 
 export class LoginPage{
     readonly page: Page;
-    readonly text_h1_UeberschriftLoginSeite: Locator;
     readonly input_username: Locator;
     readonly input_password: Locator;
     readonly button_login: Locator;
     readonly button_logoff: Locator;
-    readonly text_h1_login: Locator;
+    readonly text_h1: Locator;
+    readonly text_span_inputerror: Locator;
 
     constructor(page){
         this.page = page;  
-        this.text_h1_login = page.getByRole('heading', { name: 'Sign in to your account' });
+        this.text_h1 = page.getByRole('heading', { name: 'Sign in to your account' });
         this.input_username = page.getByLabel('Username or email');
         this.input_password = page.getByLabel('Password');
-        this.button_login = page.getByRole('button', { name: 'Sign In' })
+        this.button_login = page.getByRole('button', { name: 'Sign In' });
+        this.text_span_inputerror = page.getByText('Invalid username or password.');
     }
 
     async login(username, password){
-        await expect(this.text_h1_login).toBeVisible();
+        await expect(this.text_h1).toBeVisible();
         await this.input_username.click();
         await this.input_username.fill(username);
         await this.input_password.click();

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -25,4 +25,19 @@ test.describe(`Testfälle für die Authentifizierung: Umgebung: ${process.env.UM
       await expect(Start.text_h2_Ueberschrift).toBeVisible();
     })
   })  
+
+  test('Erfolgloser Login mit falschem Passwort', async ({ page }) => {
+    const Login = new LoginPage(page);
+    const Landing = new LandingPage(page);
+    const Menue = new MenuePage(page);
+  
+    await test.step(`Anmelden mit Benutzer ${USER}`, async () => {
+      await page.goto(URL_PORTAL);
+      await expect(Landing.text_h1_UeberschriftStartseite).toBeVisible();
+      await Menue.button_Anmelden.click();
+      await Login.login(USER, 'Mickeymouse');
+      await expect(Login.text_span_inputerror).toBeVisible();
+      await expect(Login.text_h1).toBeVisible();
+    })
+  })
 })


### PR DESCRIPTION
# Description

<!--
 - Neuer Testfall für den Test des korrekten Verhaltens bei Eingabe eines ungültigen Passwortes
 - überflüssigen dev-branch aus Playwright-yml entfernt
 - schedule-actions läuft jetzt nur einmal um 6 Uhr anstatt eine Stunde lang immer wieder
-->

## Links to Tickets or other PRs

<!--
-->

## Notes

<!--
-->


## Approval for review
