### PR TITLE
Testfälle für die Menüleiste fertig

### DIFF
--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -1,0 +1,22 @@
+## Fehlende data-testid
+# Erläuterung
+Der Playwright-Codegenerator ist ein sehr wirkungsvolles tool um schnell Ausdrücke für die Elemente auf einer Webseite automatisch zu erstellen.
+Der FE-Entwickler des Clients muss das Attribut "data-testid" für jedes Element einfügen, welches für die Playwright-Testautomatisierung relevant ist.
+Welche Elemente relevant sind, weiss der Entwickler zum Zeitpunkt der Entwicklung des FE nicht und kann deshalb die data-testids nur erraten.
+
+# Hinweise für die Vergabe einer data-testid im FE
+Die data-testid muss genau in dem Bereich liegen, in dem der Endanwender auch tatsächlich den Klick ausführt.
+
+## Liste der fehlenden oder nicht korrekt plazierten data-testid
+# menu.page.ts
+"NAVIGATION": <div class="v-list-item-title">Navigation</div>
+"Benutzerverwaltung": <div class="v-list-item-title">Benutzerverwaltung</div>
+"Neue Benutzer anlegen": <div class="v-list-item-title">Neue Benutzer anlegen</div>
+"Klassenverwaltung": <div class="v-list-item-title">Klassenverwaltung</div>
+"Rollenverwaltung": <div class="v-list-item-title">Rollenverwaltung</div>
+"Alle Rollen anzeigen": <div class="v-list-item-title">Alle Rollen anzeigen</div>
+"Schulverwaltung": <div class="v-list-item-title">Schulverwaltung</div>
+"Schulträgerverwaltung": <div class="v-list-item-title">Schulträgerverwaltung</div>
+
+# start.page.ts
+"Alle Angebote": <h2 class="text-h4">Alle Angebote</h2>

--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -1,22 +1,29 @@
-## Fehlende data-testid
-# Erläuterung
+# Fehlende data-testid
+## Erläuterung
 Der Playwright-Codegenerator ist ein sehr wirkungsvolles tool um schnell Ausdrücke für die Elemente auf einer Webseite automatisch zu erstellen.
 Der FE-Entwickler des Clients muss das Attribut "data-testid" für jedes Element einfügen, welches für die Playwright-Testautomatisierung relevant ist.
 Welche Elemente relevant sind, weiss der Entwickler zum Zeitpunkt der Entwicklung des FE nicht und kann deshalb die data-testids nur erraten.
 
-# Hinweise für die Vergabe einer data-testid im FE
-Die data-testid muss genau in dem Bereich liegen, in dem der Endanwender auch tatsächlich den Klick ausführt.
+## Hinweise für die Vergabe einer data-testid im FE
+Die data-testid muss genau in dem Bereich liegen, in dem der Endanwender auch tatsächlich den Klick ausführt, oder auch dort wo das Auge des Anwenders hinschaut(auf die Texte)
 
 ## Liste der fehlenden oder nicht korrekt plazierten data-testid
-# menu.page.ts
-"NAVIGATION": <div class="v-list-item-title">Navigation</div>
-"Benutzerverwaltung": <div class="v-list-item-title">Benutzerverwaltung</div>
-"Neue Benutzer anlegen": <div class="v-list-item-title">Neue Benutzer anlegen</div>
-"Klassenverwaltung": <div class="v-list-item-title">Klassenverwaltung</div>
-"Rollenverwaltung": <div class="v-list-item-title">Rollenverwaltung</div>
-"Alle Rollen anzeigen": <div class="v-list-item-title">Alle Rollen anzeigen</div>
-"Schulverwaltung": <div class="v-list-item-title">Schulverwaltung</div>
-"Schulträgerverwaltung": <div class="v-list-item-title">Schulträgerverwaltung</div>
+## menu.page.ts
+"NAVIGATION": div class="v-list-item-title">Navigation</div>
 
-# start.page.ts
-"Alle Angebote": <h2 class="text-h4">Alle Angebote</h2>
+"Benutzerverwaltung": div class="v-list-item-title">Benutzerverwaltung</div>
+
+"Neue Benutzer anlegen": div class="v-list-item-title">Neue Benutzer anlegen</div>
+
+"Klassenverwaltung": div class="v-list-item-title">Klassenverwaltung</div>
+
+"Rollenverwaltung": div class="v-list-item-title">Rollenverwaltung</div>
+
+"Alle Rollen anzeigen": div class="v-list-item-title">Alle Rollen anzeigen</div>
+
+"Schulverwaltung": div class="v-list-item-title">Schulverwaltung</div>
+
+"Schulträgerverwaltung": div class="v-list-item-title">Schulträgerverwaltung</div>
+
+## start.page.ts
+"Alle Angebote": h2 class="text-h4">Alle Angebote</h2>

--- a/pages/itslearning.page.ts
+++ b/pages/itslearning.page.ts
@@ -6,6 +6,6 @@ export class ItsLearningPage{
 
     constructor(page){
         this.page = page;  
-        this.text_h1 = page.getByRole('heading', { name: 'Schulen des Landes Schleswig-Holstein' });
+        this.text_h1 = page.getByRole('heading', { name: 'Die Lernplattform für den' });
     }
 }

--- a/pages/landing.page.ts
+++ b/pages/landing.page.ts
@@ -2,7 +2,6 @@ import { type Locator, Page } from '@playwright/test';
 
 export class LandingPage{
     readonly page: Page;
-    readonly text_h1_UeberschriftStartseite: Locator;
     readonly text_Willkommen: Locator;
     readonly button_Anmelden: Locator;
 

--- a/pages/login.page.ts
+++ b/pages/login.page.ts
@@ -16,7 +16,7 @@ export class LoginPage{
     constructor(page){
         this.page = page;  
         this.text_h1 = page.getByRole('heading', { name: 'Sign in to your account' });
-        this.text_h1_updatePW = page.getByText('You need to change your password to activate your account.')
+        this.text_h1_updatePW = page.getByText('You need to change your password to activate your account.');
         this.input_username = page.locator('#username');
         this.input_password = page.locator('#password');
         this.input_NewPassword = page.getByLabel('New Password');

--- a/pages/menu.page.ts
+++ b/pages/menu.page.ts
@@ -1,0 +1,31 @@
+import { type Locator, Page } from '@playwright/test';
+
+export class MenuPage{
+    readonly page: Page;
+    readonly header_label_Navigation: Locator;
+    readonly button_BackStartpage: Locator;
+    readonly label_Benutzerverwaltung: Locator;
+    readonly menueItem_AlleBenutzerAnzeigen: Locator;
+    readonly menueItem_BenutzerAnlegen: Locator;
+    readonly label_Klassenverwaltung: Locator;
+    readonly label_Rollenverwaltung: Locator;
+    readonly menueItem_AlleRollenAnzeigen: Locator;
+    readonly menueItem_RolleAnlegen: Locator;
+    readonly label_Schulverwaltung: Locator;
+    readonly label_Schultraegerverwaltung: Locator;
+
+    constructor(page){
+        this.page = page;  
+        this.header_label_Navigation = page.getByText('Navigation');
+        this.button_BackStartpage = page.getByTestId('back-to-start-link');
+        this.label_Benutzerverwaltung =  page.getByText('Benutzerverwaltung').first();
+        this.menueItem_AlleBenutzerAnzeigen = page.getByTestId('user-management-menu-item');
+        this.menueItem_BenutzerAnlegen = page.getByText('Neue Benutzer anlegen');
+        this.label_Klassenverwaltung = page.getByText('Klassenverwaltung');
+        this.label_Rollenverwaltung = page.getByText('Rollenverwaltung');
+        this.menueItem_AlleRollenAnzeigen = page.getByText('Alle Rollen anzeigen');
+        this.menueItem_RolleAnlegen = page.getByTestId('rolle-creation-menu-item');
+        this.label_Schulverwaltung = page.getByText('Schulverwaltung');
+        this.label_Schultraegerverwaltung =  page.getByText('Schulträgerverwaltung');
+    }
+}

--- a/pages/start.page.ts
+++ b/pages/start.page.ts
@@ -10,8 +10,8 @@ export class StartPage{
     constructor(page){
         this.page = page;  
         this.text_h2_Ueberschrift = page.getByRole('heading', { name: 'Alle Angebote' });  
-        this.card_item_email = page.getByTestId('provider-card-1');
-        this.card_item_itslearning = page.getByTestId('provider-card-2');
+        this.card_item_email = page.getByTestId('provider-card-8f448f82-0be3-4d82-9cb1-2e67f277796f');
+        this.card_item_itslearning = page.getByTestId('provider-card-ecc794a3-f94f-40f6-bef6-bd4808cf64d4');
         this.card_item_schulportal_administration = page.getByTestId('provider-card-admin');
     }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,7 +42,10 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome']},
+      use: { 
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1281, height: 720}
+      },
     },
 
     // {

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -8,7 +8,7 @@ const USER = process.env.USER;
 const URL_PORTAL = process.env.URL_PORTAL;
 
 test.describe(`Testfälle für die Authentifizierung: Umgebung: ${process.env.UMGEBUNG}: URL: ${process.env.URL_PORTAL}:`, () => {
-  test('SPSH-63 Erfolgreicher Standard Login ohne Rolle', async ({ page }) => {
+  test('Erfolgreicher Standard Login ohne Rolle', async ({ page }) => {
     const Login = new LoginPage(page);
     const Landing = new LandingPage(page);
     const Start = new StartPage(page);
@@ -21,7 +21,7 @@ test.describe(`Testfälle für die Authentifizierung: Umgebung: ${process.env.UM
     })
   })  
   
-  test('SPSH-109 Erfolgloser Login mit falschem Passwort', async ({ page }) => {
+  test('Erfolgloser Login mit falschem Passwort', async ({ page }) => {
     const Login = new LoginPage(page);
     const Landing = new LandingPage(page);
   

--- a/tests/logoff.spec.ts
+++ b/tests/logoff.spec.ts
@@ -9,9 +9,9 @@ const USER = process.env.USER;
 const URL_PORTAL = process.env.URL_PORTAL;
 
 test.describe(`Testfälle für die Authentifizierung: Umgebung: ${process.env.UMGEBUNG}: URL: ${process.env.URL_PORTAL}:`, () => {
-  test('SPSH-185 Erfolgreicher Standard Logoff', async ({ page }) => {
+  test('Erfolgreicher Standard Logoff', async ({ page }) => {
     const Landing = new LandingPage(page);
-    const Startseite = new StartPage(page)
+    const Startseite = new StartPage(page);
     const Login = new LoginPage(page);
     const Header = new HeaderPage(page);
 

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { LandingPage } from '../pages/landing.page';
+import { StartPage } from '../pages/start.page';
+import { LoginPage } from '../pages/login.page';
+import { MenuPage } from '../pages/menu.page';
+
+const PW = process.env.PW;
+const USER = process.env.USER;
+const URL_PORTAL = process.env.URL_PORTAL;
+
+test.describe(`Testfälle für die Hauptmenue-Leiste: Umgebung: ${process.env.UMGEBUNG}: URL: ${process.env.URL_PORTAL}:`, () => {
+  test('Test der Hauptenue-Leiste und Untermenues auf Vollständigkeit', async ({ page }) => {
+    const Landing = new LandingPage(page);
+    const Startseite = new StartPage(page)
+    const Login = new LoginPage(page);
+    const Menu = new MenuPage(page);
+
+    await test.step(`Annmelden mit Benutzer ${USER}`, async () => {
+      await page.goto(URL_PORTAL);
+      await Landing.button_Anmelden.click();
+      await Login.login(USER, PW); 
+      await expect(Startseite.text_h2_Ueberschrift).toBeVisible();
+    })
+
+    await test.step(`Pruefen der Hauptmenueleiste mit Untermenues`, async () => {
+      await Startseite.card_item_schulportal_administration.click();
+      await expect(Menu.header_label_Navigation).toBeVisible();
+      await expect(Menu.button_BackStartpage).toBeVisible();
+      await expect(Menu.label_Benutzerverwaltung).toBeVisible();
+      await expect(Menu.menueItem_AlleBenutzerAnzeigen).toBeVisible();
+      await expect(Menu.menueItem_BenutzerAnlegen).toBeVisible();
+      await expect(Menu.label_Klassenverwaltung).toBeVisible();
+      await expect(Menu.label_Rollenverwaltung).toBeVisible();
+      await expect(Menu.menueItem_AlleRollenAnzeigen).toBeVisible();
+      await expect(Menu.menueItem_RolleAnlegen).toBeVisible();
+      await expect(Menu.label_Schulverwaltung).toBeVisible();
+      await expect(Menu.label_Schultraegerverwaltung).toBeVisible();
+    })    
+  })  
+
+  test('Test der Funktion "Zuück zur Starseite"', async ({ page }) => {
+    const Landing = new LandingPage(page);
+    const Startseite = new StartPage(page)
+    const Login = new LoginPage(page);
+    const Menu = new MenuPage(page);
+
+    await test.step(`Annmelden mit Benutzer ${USER}`, async () => {
+      await page.goto(URL_PORTAL);
+      await Landing.button_Anmelden.click();
+      await Login.login(USER, PW); 
+      await expect(Startseite.text_h2_Ueberschrift).toBeVisible();
+    })
+
+    await test.step(`Menue-Eintrag zum Rücksprung auf die Startseite klicken`, async () => {
+      await Startseite.card_item_schulportal_administration.click();
+      await expect(Menu.header_label_Navigation).toBeVisible();
+      await Menu.button_BackStartpage.click();
+      await expect(Startseite.text_h2_Ueberschrift).toBeVisible();
+    })
+  })  
+})

--- a/tests/workflow.spec.ts
+++ b/tests/workflow.spec.ts
@@ -13,7 +13,7 @@ const USER = process.env.USER;
 const URL_PORTAL = process.env.URL_PORTAL;
 
 test.describe(`Testfälle für den Test von workflows: Umgebung: ${process.env.UMGEBUNG}: URL: ${process.env.URL_PORTAL}:`, () => {
-  test('SPSH-122 Angebote per Link öffnen', async ({ page}) => {
+  test('Angebote per Link öffnen', async ({ page}) => {
     const Landing = new LandingPage(page);
     const Login = new LoginPage(page);
     const Startseite = new StartPage(page);
@@ -33,13 +33,13 @@ test.describe(`Testfälle für den Test von workflows: Umgebung: ${process.env.U
       await Startseite.card_item_email.click();
       const page_Email4Teacher = await  page_Email4Teacher_Promise; 
       const Email4Teacher = new Email4TeacherPage(page_Email4Teacher);
-      await Email4Teacher.text_h1.click();
+      await expect(Email4Teacher.text_h1).toBeVisible();
 
       const page_Itslearning_Promise = page.waitForEvent('popup');
       await Startseite.card_item_itslearning.click();
       const page_Itslearning = await  page_Itslearning_Promise; 
       const Itslearning = new ItsLearningPage(page_Itslearning);
-      await Itslearning.text_h1.click();
+      await expect(Itslearning.text_h1).toBeVisible();
       
       await page_Itslearning.close();
       await page_Email4Teacher.close();
@@ -50,7 +50,7 @@ test.describe(`Testfälle für den Test von workflows: Umgebung: ${process.env.U
     })
   })  
 
-  test('SPSH-215 Passwort Reset', async ({ page}) => {
+  test('Passwort Reset', async ({ page}) => {
     const Landing = new LandingPage(page);
     const Login = new LoginPage(page);
     const Startseite = new StartPage(page);


### PR DESCRIPTION
# Description

  1) Es gibt 2 neue Testfälle in menu.spec.ts. Die testen nur die Menue bar.
  2) developer-notes.md: Hier ein Vorschlag wie wir mit fehlenden data-testids umgehen. Gedacht ist, dass ich das in der developer-notes.md dokumentiere, und wenn sich genug angesammelt hat, fixen wir das über ein bug/story im FE. Interessant für mich ist, ob die Vergabe der ids nach meinen Vorstellungen so umsetzbar ist. Ich habe das erstmal nur für  menu.page.ts und start.page.ts aufgelistet.
