### PR TITLE
fix locators test.dev und main.dev

### DIFF
--- a/pages/MenuBar.page.ts
+++ b/pages/MenuBar.page.ts
@@ -18,9 +18,9 @@ export class MenuPage{
         this.page = page;  
         this.header_label_Navigation = page.locator('[data-testid="menu-bar-title"] .v-list-item-title');
         this.button_BackStartpage = page.getByTestId('back-to-start-link');
-        this.label_Benutzerverwaltung =  page.locator('[data-testid="person-management-title"] .v-list-item-title');        
-        this.menueItem_AlleBenutzerAnzeigen = page.getByTestId('user-management-menu-item');
-        this.menueItem_BenutzerAnlegen = page.locator('[data-testid="user-creation-menu-item"] .v-list-item-title'); 
+        this.label_Benutzerverwaltung =  page.locator('[data-testid="person-management-title"] .v-list-item-title'); 
+        this.menueItem_AlleBenutzerAnzeigen = page.getByTestId('person-management-menu-item');
+        this.menueItem_BenutzerAnlegen =  page.getByTestId('person-creation-menu-item'); 
         this.label_Klassenverwaltung = page.locator('[data-testid="klasse-management-title"] .v-list-item-title');
         this.label_Rollenverwaltung = page.locator('[data-testid="rolle-management-title"] .v-list-item-title');
         this.menueItem_AlleRollenAnzeigen = page.locator('[data-testid="rolle-management-menu-item"] .v-list-item-title');

--- a/pages/StartView.page.ts
+++ b/pages/StartView.page.ts
@@ -10,8 +10,8 @@ export class StartPage{
     constructor(page){
         this.page = page;  
         this.text_h2_Ueberschrift = page.getByTestId('all-service-provider-title');
-        this.card_item_email = page.getByTestId('provider-card-8f448f82-0be3-4d82-9cb1-2e67f277796f');
-        this.card_item_itslearning = page.getByTestId('provider-card-ecc794a3-f94f-40f6-bef6-bd4808cf64d4');
-        this.card_item_schulportal_administration = page.getByTestId('provider-card-admin');
+        this.card_item_email = page.locator('[href="https://de.wikipedia.org/wiki/E-Mail"]');
+        this.card_item_itslearning = page.locator('[href="https://itslearning.com/de"]');
+        this.card_item_schulportal_administration = page.getByTestId('service-provider-card-admin');
     }
 }


### PR DESCRIPTION
# Description

- die beiden testids menueItem_AlleBenutzerAnzeigen  und menueItem_BenutzerAnlegen waren nicht aktuell
- die beiden dynamischen ids card_item_email und card_item_itslearning können so nicht verwendet werden