### PR TITLE
Testfall Ergebnisliste Schuule auf Vollstaendigkeit pruefen fertig

### DIFF
--- a/.github/workflows/schedule_staging.yml
+++ b/.github/workflows/schedule_staging.yml
@@ -1,7 +1,7 @@
 name: Scheduled Playwright Smoketest(staging) 
 on:
   schedule:
-    - cron: '10 6 * * *'
+    - cron: '10 5 * * *'
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/schedule_test.yml
+++ b/.github/workflows/schedule_test.yml
@@ -1,7 +1,7 @@
 name: Scheduled Playwright Smoketest(test.dev) 
 on:
   schedule:
-    - cron: '10 6 * * *'
+    - cron: '10 5 * * *'
 jobs:
   test:
     timeout-minutes: 60

--- a/pages/MenuBar.page.ts
+++ b/pages/MenuBar.page.ts
@@ -12,6 +12,7 @@ export class MenuPage{
     readonly menueItem_AlleRollenAnzeigen: Locator;
     readonly menueItem_RolleAnlegen: Locator;
     readonly label_Schulverwaltung: Locator;
+    readonly menueItem_AlleSchulenAnzeigen: Locator;
     readonly label_Schultraegerverwaltung: Locator;
 
     constructor(page){
@@ -26,6 +27,7 @@ export class MenuPage{
         this.menueItem_AlleRollenAnzeigen = page.locator('[data-testid="rolle-management-menu-item"] .v-list-item-title');
         this.menueItem_RolleAnlegen = page.getByTestId('rolle-creation-menu-item');
         this.label_Schulverwaltung = page.locator('[data-testid="schule-management-title"] .v-list-item-title');
+        this.menueItem_AlleSchulenAnzeigen = page.locator('[data-testid="schule-management-menu-item"] .v-list-item-title');
         this.label_Schultraegerverwaltung =  page.locator('[data-testid="schultraeger-management-title"] .v-list-item-title');
     }
 }

--- a/pages/admin/SchuleManagementView.page.ts
+++ b/pages/admin/SchuleManagementView.page.ts
@@ -1,0 +1,17 @@
+import { type Locator, Page } from '@playwright/test';
+
+export class SchuleManagementViewPage{
+    readonly page: Page;
+    readonly text_h1_Administrationsbereich: Locator;
+    readonly text_h2_Schulverwaltung: Locator;
+    readonly table_header_Dienstellennummer: Locator;
+    readonly table_header_Schulname: Locator;
+   
+    constructor(page){
+        this.page = page;  
+        this.text_h1_Administrationsbereich = page.getByTestId('admin-headline');
+        this.text_h2_Schulverwaltung = page.getByTestId('layout-card-headline');
+        this.table_header_Dienstellennummer = page.getByText('Dienststellennummer');
+        this.table_header_Schulname = page.getByText('Schulname');
+    }
+}

--- a/tests/Person.spec.ts
+++ b/tests/Person.spec.ts
@@ -23,8 +23,8 @@ test.describe(`Testfälle für die Administration von Personen: Umgebung: ${proc
     const Header = new HeaderPage(page);
 
     const Rolle = 'Lehrkraft';
-    const Vorname = 'TAutoV' + faker.person.firstName();
-    const Nachname = 'TAutoN' + faker.person.lastName();;
+    const Vorname = 'TAutoV' + faker.person.firstName(); 
+    const Nachname = 'TAutoN' + faker.person.lastName() + '-' + faker.person.lastName(); // Wahrscheinlichkeit doppelter Namen verringern
     const Schulstrukturknoten = '(Testschule Schulportal)'; 
     let Benutzername= '';
     let Einstiegspasswort = '';

--- a/tests/Rolle.spec.ts
+++ b/tests/Rolle.spec.ts
@@ -20,8 +20,8 @@ test.describe(`Testfälle für die Administration von Rollen: Umgebung: ${proces
     const RolleCreationView = new RolleCreationViewPage(page);
     const RolleManagementeView = new RolleManagementViewPage(page);
 
-    const ROLLENNAME1 = 'TAutoR1' + faker.word.noun();
-    const ROLLENNAME2 = 'TAutoR2' + faker.word.noun();
+    const ROLLENNAME1 = 'TAutoR1' + faker.word.noun() + '-' + faker.word.noun(); // Wahrscheinlichkeit doppelter Namen verringern
+    const ROLLENNAME2 = 'TAutoR2' + faker.word.noun() + '-' + faker.word.noun();
     const SCHULSTRUKTURKNOTEN1 = 'Wurzel Land Schleswig Holstein';
     const SCHULSTRUKTURKNOTEN2 = 'Amalie-Sieveking-Schule';
     const ROLLENART1 = 'Lern'
@@ -75,7 +75,7 @@ test.describe(`Testfälle für die Administration von Rollen: Umgebung: ${proces
     })
   })  
 
-  test('Gesamtübersicht Rollen auf Vollständigkeit prüfen', async ({ page }) => {
+  test('Ergebnisliste Rollen auf Vollständigkeit prüfen', async ({ page }) => {
     const Landing = new LandingPage(page);
     const Startseite = new StartPage(page);
     const Login = new LoginPage(page);

--- a/tests/Schule.spec.ts
+++ b/tests/Schule.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { LandingPage } from '../pages/LandingView.page';
+import { LoginPage } from '../pages/LoginView.page';
+import { StartPage } from '../pages/StartView.page';
+import { MenuPage } from '../pages/MenuBar.page';
+import { SchuleManagementViewPage } from '../pages/admin/SchuleManagementView.page';
+
+const PW = process.env.PW;
+const ADMIN = process.env.USER;
+const FRONTEND_URL = process.env.FRONTEND_URL;
+
+test.describe(`Testfälle für die Administration von Schulen: Umgebung: ${process.env.UMGEBUNG}: URL: ${process.env.FRONTEND_URL}:`, () => {
+  test('Ergebnisliste Schulen auf Vollständigkeit prüfen', async ({ page }) => {
+    const Landing = new LandingPage(page);
+    const Startseite = new StartPage(page);
+    const Login = new LoginPage(page);
+    const Menue = new MenuPage(page);
+    const SchuleManagementView = new SchuleManagementViewPage(page);
+
+    await test.step(`Annmelden mit Benutzer ${ADMIN} und Schulverwaltung öffnen`, async () => {
+      await page.goto(FRONTEND_URL);
+      await Landing.button_Anmelden.click();
+      await Login.login(ADMIN, PW); 
+      await expect(Startseite.text_h2_Ueberschrift).toBeVisible();
+      await Startseite.card_item_schulportal_administration.click();
+      await Menue.menueItem_AlleSchulenAnzeigen.click();
+    })
+
+    await test.step(`Alle Elemente in der Ergebnisliste auf Existenz prüfen`, async () => {      
+      await expect(SchuleManagementView.text_h1_Administrationsbereich).toBeVisible();
+      await expect(SchuleManagementView.text_h2_Schulverwaltung).toBeVisible();
+      await expect(SchuleManagementView.text_h2_Schulverwaltung).toHaveText('Schulverwaltung');
+      await expect(SchuleManagementView.table_header_Dienstellennummer).toBeVisible();
+      await expect(SchuleManagementView.table_header_Schulname).toBeVisible();
+    })
+  })  
+})


### PR DESCRIPTION
- Neuer Testfall 'Ergebnisliste Schulen' auf Vollständigkeit prüfen: https://ticketsystem.dbildungscloud.de/browse/SPSH-511
- schedule.yml eine Stunde früher damit die Ergebnisse um 7:15 Uhr vorliegen anstatt 8:15
- Bei der Namensvergabe faker 2 mal Nacheinander ausführen, damit wenn die Tests mehrmals nacheinander laufen, die Wahrscheinlichkeit doppelter Namen reduziert wird. Dieses hat in der Vergangenheit bei der Suche von Namen in den Ergebnislisten zu Problemen geführt.