### PR TITLE
Ops 6379 fix playwright browser installation error

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,8 +31,11 @@ jobs:
       with:
         node-version: 16
       
-    - name: Update Packages
-      run: sudo apt-get update || true
+    - name: Remove Microsoft APT and  Updat Packages
+      run: |
+        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get update || true
+
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,6 +30,11 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16
+      
+    - name: Remove Microsoft APT and  Updat Package
+      run: |
+        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get update
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,12 +31,7 @@ jobs:
       with:
         node-version: 16
       
-    #- name: Remove Microsoft APT and  Updat Packages
-    #  run: |
-    #    # sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-    #    sudo apt-get update || true
-
-    - name: Updat Packages
+    - name: Update Packages
       run: sudo apt-get update || true
 
     - name: Install dependencies

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,10 +31,14 @@ jobs:
       with:
         node-version: 16
       
-    - name: Remove Microsoft APT and  Updat Package
-      run: |
-        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-        sudo apt-get update
+    #- name: Remove Microsoft APT and  Updat Packages
+    #  run: |
+    #    # sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+    #    sudo apt-get update || true
+
+    - name: Updat Packages
+      run: sudo apt-get update || true
+
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         node-version: 16
       
-    - name: Remove Microsoft APT and  Updat Packages
+    - name: Remove Microsoft APT and  Update Packages
       run: |
         sudo rm /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update || true


### PR DESCRIPTION
# Description
We are encountering an issue while installing browsers through Playwright, specifically with fetching the Microsoft repository for Ubuntu 22.04.The error indicates that the repository's signing is invalid, resulting in a failed installation process

[Playwright Tests · dBildungsplattform/schulportal-testautomatisierung@eaeede5 (github.com)](https://github.com/dBildungsplattform/schulportal-testautomatisierung/actions/runs/8814759343/job/24198055469)

**The solution has been documented in this PR :
https://github.com/microsoft/linux-package-repositories/issues/130**
<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.