### PR TITLE
fix playwright browser schedule

### DIFF
--- a/.github/workflows/schedule_staging.yml
+++ b/.github/workflows/schedule_staging.yml
@@ -11,6 +11,10 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16
+    - name: Remove Microsoft APT and  Update Packages
+      run: |
+          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update || true
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers

--- a/.github/workflows/schedule_test.yml
+++ b/.github/workflows/schedule_test.yml
@@ -11,6 +11,10 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16
+    - name: Remove Microsoft APT and  Update Packages
+      run: |
+        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get update || true
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers


### PR DESCRIPTION
Dieser fix behebt den microsoft-bug bei der Installation der Playwright-Browser.
In der playwright.yml wurde das bereits durch SRE gemacht.