### PR TITLE
SPSH-816: Anpassung des Names der Schulstrukturknote bei der Anlage der Rollen.

### DIFF
--- a/tests/Rolle.spec.ts
+++ b/tests/Rolle.spec.ts
@@ -36,7 +36,7 @@ test.describe(`Testfälle für die Administration von Rollen: Umgebung: ${proces
     const ROLLENNAME2 =
       "TAuto-PW-R2-" + faker.lorem.word({ length: { min: 8, max: 12 } });
     const SCHULSTRUKTURKNOTEN1 = "Land Schleswig-Holstein";
-    const SCHULSTRUKTURKNOTEN2 = "Amalie-Sieveking-Schule";
+    const SCHULSTRUKTURKNOTEN2 = "0703754 (Amalie-Sieveking-Schule)";
     const ROLLENART1 = "Lern";
     const ROLLENART2 = "Lehr";
 


### PR DESCRIPTION

# Description
Anpassung des Names der Schulstrukturknote bei der Anlage der Rollen damit die Test-Schule nach Text (Kennung + Name) gewählt werden kann.
Alter Name: Amalie-Sieveking-Schule
Neuer Name: 0703754 (Amalie-Sieveking-Schule)

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/SPSH-816
https://github.com/dBildungsplattform/dbildungs-iam-server/pull/564

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.