### PR TITLE
SPSH-1002: Implemented 2 test cases

### DIFF
--- a/pages/ProfileView.page.ts
+++ b/pages/ProfileView.page.ts
@@ -33,6 +33,10 @@ export class ProfilePage{
     readonly cardHeadline_Passwort: Locator;
     readonly icon_Schluessel_Passwort: Locator;
     readonly button_NeuesPasswortSetzen: Locator;
+    readonly button_PasswortAendern: Locator;
+    readonly label_username: Locator;
+    readonly text_p_LoginPrompt: Locator;
+    readonly input_password: Locator;
     // 2FA
     readonly cardHeadline_2FA: Locator;
     readonly icon_Schild2FA: Locator;
@@ -72,9 +76,15 @@ export class ProfilePage{
         // Passwort
         this.cardHeadline_Passwort = page.getByTestId('new-password-card');
         this.button_NeuesPasswortSetzen = page.getByTestId('open-change-password-dialog');
+        this.button_PasswortAendern = page.getByTestId('change-password-button');
+        this.label_username = page.locator('#kc-attempted-username');
+        this.text_p_LoginPrompt = page.getByTestId('login-prompt-text');
+        this.input_password = page.getByTestId('password-input');
+        
          // 2FA
          this.cardHeadline_2FA = page.getByTestId('two-factor-card');
          this.text_no2FA = page.getByText('Es wurde noch kein zweiter Faktor für Sie eingerichtet.');
          this.button_2FAEinrichten = page.getByTestId('open-2FA-self-service-dialog-icon');
+         
     }
 }

--- a/tests/Profile.spec.ts
+++ b/tests/Profile.spec.ts
@@ -374,4 +374,50 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
       // await expect(profileView.button_2FAEinrichten).toBeEnabled();
     });
   });
+
+  test("Das eigene Profil öffnen, Passwort Ändern öffnen, und Status des Benutzernamenfelds prüfen ", {tag: [LONG, STAGE]}, async ({ page }) => {
+    const profileView = new ProfilePage(page);
+    const header = new HeaderPage(page);
+    const login = new LoginPage(page);
+
+    const vorname = "TAuto-PW-V-" + faker.person.firstName();
+    const nachname = "TAuto-PW-N-" + faker.person.lastName();
+    const organisation = 'Testschule Schulportal';
+    const rollenname = 'TAuto-PW-R-RolleSchüler';
+    const rollenart = 'LERN';
+
+    await test.step(`Lehrer via api anlegen und mit diesem anmelden`, async () => {
+      const idSP = await getSPId(page, 'itslearning');
+      const userInfo: UserInfo = await createRolleAndPersonWithUserContext(page, organisation, rollenart, nachname, vorname, idSP, rollenname);
+      roleId.push(userInfo.rolleId);
+      username.push(userInfo.username);
+
+      await header.logout();
+      await header.button_login.click();
+      await login.login(userInfo.username, userInfo.password);
+      await login.UpdatePW();
+    });
+
+    await test.step(`Profil öffnen`, async () => {
+      await header.button_profil.click();
+    });
+
+    await test.step(`Passwort Ändern öffnen`, async () => {
+      await expect(profileView.button_ZurueckVorherigeSeite).toBeVisible();
+      await expect(profileView.text_h2_Ueberschrift).toHaveText('Mein Profil');
+      // Passwort
+      await expect(profileView.cardHeadline_Passwort).toHaveText('Passwort');
+      await expect(profileView.button_NeuesPasswortSetzen).toBeEnabled();
+
+      profileView.button_NeuesPasswortSetzen.click();
+      profileView.button_PasswortAendern.click();
+    });
+
+    await test.step(`Status des Benutzernamenfelds prüfen`, async () => {
+      await expect(profileView.label_username).toHaveText(username[0]); // Benutzername ist nicht änderbar weil es nur Text ist
+      await expect(profileView.text_p_LoginPrompt).toHaveText('Bitte geben Sie Ihr aktuelles Passwort ein.');
+      await expect(profileView.input_password).toBeEnabled();
+      await page.goBack();
+    });
+  });
 });

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -135,4 +135,27 @@ test.describe(`Testfälle für die Authentifizierung: Umgebung: ${process.env.UM
       loggedIn = false;
     })
   })
+
+  test('Erfolgloser Login mit falschem Benutzernamen und gültigem Passwort in der Rolle Landesadmin', {tag: [LONG, STAGE]}, async ({ page }) => {
+    const login = new LoginPage(page);
+    const landing = new LandingPage(page);
+    const start = new StartPage(page);
+
+    await test.step('Anmelden mit falschem Benutzernamen fake-username, Inputfeld für Benutzernamen bleibt änderbar', async () => {
+      await page.goto(FRONTEND_URL);
+      await expect(landing.text_Willkommen).toBeVisible();
+      await landing.button_Anmelden.click();
+      await login.login('fake-username', PW);
+      await expect(login.text_span_inputerror).toBeVisible();
+      await expect(login.text_h1).toBeVisible();
+      await expect(login.input_username).toBeEditable();
+      loggedIn = false;
+    })
+
+    await test.step(`Anmelden mit Benutzer ${ADMIN}`, async () => {
+      await login.login(ADMIN, PW);
+      await expect(start.text_h2_Ueberschrift).toBeVisible();
+      loggedIn = true;
+    })
+  })
 })


### PR DESCRIPTION

# Description
2 Testfälle:

- Falschen Benutzernamen angeben und Inputfeld für Benutzernamen bleibt editierbar.
- Bei Passwortänderung ist der Benutzername nicht editierbar (änderbar)

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/SPSH-1002

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.