### PR TITLE
SPSH-1359: Problem mit doppelten Rollennamen gelöst

### DIFF
--- a/base/testHelperGenerateTestdataNames.ts
+++ b/base/testHelperGenerateTestdataNames.ts
@@ -8,7 +8,7 @@ export async function generateLehrerNachname(){
   return "TAuto-PW-N-" + faker.person.lastName();
 }
 
-export async function generateRolleName(){  
+export function generateRolleName(){  
   return "TAuto-PW-R-" + faker.lorem.word({ length: { min: 8, max: 12 }});
 }
 

--- a/tests/Person.spec.ts
+++ b/tests/Person.spec.ts
@@ -15,6 +15,7 @@ import { addSystemrechtToRolle } from "../base/api/testHelperRolle.page";
 import { LONG, SHORT, STAGE } from "../base/tags";
 import { deletePersonByUsername, deleteRolleById, deleteRolleByName } from "../base/testHelperDeleteTestdata.ts";
 import { landesadminRolle, schuelerRolle, schuladminOeffentlichRolle } from "../base/roles.ts";
+import { generateRolleName } from "../base/testHelperGenerateTestdataNames.ts";
 
 const PW = process.env.PW;
 const ADMIN = process.env.USER;
@@ -229,7 +230,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       // Step 1:  Create a Schuladmin as Landesadmin and login as the newly created Schuladmin user
       await test.step(`Schuladmin anlegen und mit diesem anmelden`, async () => {
         const idSP = await getSPId(page, 'Schulportal-Administration');
-        userInfo = await createRolleAndPersonWithUserContext(page, schulstrukturknoten, 'LEIT', nachname, vorname, idSP, 'TAuto-PW-E-RolleLEIT');
+        userInfo = await createRolleAndPersonWithUserContext(page, schulstrukturknoten, 'LEIT', nachname, vorname, idSP, generateRolleName());
         await addSystemrechtToRolle(page, userInfo.rolleId, 'PERSONEN_VERWALTEN');
         await addSystemrechtToRolle(page, userInfo.rolleId, 'PERSONEN_ANLEGEN');
 
@@ -518,7 +519,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
     await test.step(`Testdaten: Landesadmin anlegen und mit diesem anmelden`, async () => {
       const idSP = await getSPId(page, 'Schulportal-Administration');
-      userInfo = await createRolleAndPersonWithUserContext(page, 'Land Schleswig-Holstein', 'SYSADMIN', 'TAuto-PW-B-Master', 'TAuto-PW-B-Hans', idSP, 'TAuto-PW-R-RolleSYSADMIN');
+      userInfo = await createRolleAndPersonWithUserContext(page, 'Land Schleswig-Holstein', 'SYSADMIN', 'TAuto-PW-B-Master', 'TAuto-PW-B-Hans', idSP, generateRolleName());
       await addSystemrechtToRolle(page, userInfo.rolleId, 'ROLLEN_VERWALTEN');
       await addSystemrechtToRolle(page, userInfo.rolleId, 'PERSONEN_SOFORT_LOESCHEN');
       await addSystemrechtToRolle(page, userInfo.rolleId, 'PERSONEN_VERWALTEN');
@@ -680,7 +681,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
     const vorname = "TAuto-PW-V-" + faker.person.firstName();
     const nachname = "TAuto-PW-N-" + faker.person.lastName();
-    const rolle = "TAuto-PW-R-" + faker.lorem.word({ length: { min: 8, max: 12 }});
+    const rolle = generateRolleName();
     const berechtigung = 'SYSADMIN';
     const idSP = await getSPId(page, 'Schulportal-Administration');
 

--- a/tests/PersonBearbeiten.spec.ts
+++ b/tests/PersonBearbeiten.spec.ts
@@ -81,7 +81,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
     const addminVorname = "TAuto-PW-V-" + faker.person.firstName();
     const adminNachname = "TAuto-PW-N-" + faker.person.lastName();
-    const adminRolle = "TAuto-PW-LEIT-" + faker.lorem.word({length: {min: 8, max: 12}});
+    const adminRolle = generateRolleName();
     const adminRollenart = 'LEIT';
     const adminOrganisation = 'Testschule-PW665';
     const adminIdSP = await getSPId(page, 'Schulportal-Administration');
@@ -89,7 +89,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
     const lehrerVorname = "TAuto-PW-V-" + faker.person.firstName();
     const lehrerNachname = "TAuto-PW-N-" + faker.person.lastName();
-    const lehrerRolle = "TAuto-PW-LEHR-" + faker.lorem.word({length: {min: 8, max: 12}});
+    const lehrerRolle = generateRolleName();
     const lehrerRollenart = 'LEHR';
     const lehrerOrganisation = 'Testschule-PW665';
     const lehrerIdSP = await getSPId(page, 'E-Mail');
@@ -149,7 +149,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
         const sperrDatumAb = await generateDateToday() // Konkrete Testdaten für diesen Testfall
 
         await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) und SP(email) über die api anlegen ${ADMIN}`, async () => {
-          userInfoLehrer = await createRolleAndPersonWithUserContext(page, testschule, typelehrer, await generateLehrerNachname(), await generateLehrerVorname(), await getSPId(page, email), await generateRolleName());
+          userInfoLehrer = await createRolleAndPersonWithUserContext(page, testschule, typelehrer, await generateLehrerNachname(), await generateLehrerVorname(), await getSPId(page, email), generateRolleName());
           username.push(userInfoLehrer.username);
           rolleId.push(userInfoLehrer.rolleId);
         })
@@ -175,7 +175,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
         const sperrDatumBis = await generateDateFuture(5, 2); // Konkrete Testdaten für diesen Testfall
 
         await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) und SP(email) über die api anlegen ${ADMIN}`, async () => {
-            userInfoLehrer = await createRolleAndPersonWithUserContext(page, testschule, typelehrer, await generateLehrerNachname(), await generateLehrerVorname(), await getSPId(page, email), await generateRolleName());
+            userInfoLehrer = await createRolleAndPersonWithUserContext(page, testschule, typelehrer, await generateLehrerNachname(), await generateLehrerVorname(), await getSPId(page, email), generateRolleName());
             username.push(userInfoLehrer.username);
             rolleId.push(userInfoLehrer.rolleId);
         })

--- a/tests/Profile.spec.ts
+++ b/tests/Profile.spec.ts
@@ -12,6 +12,7 @@ import { UserInfo } from "../base/api/testHelper.page";
 import { addSystemrechtToRolle } from "../base/api/testHelperRolle.page";
 import { LONG, SHORT, STAGE } from "../base/tags";
 import { deleteRolleById, deletePersonByUsername} from "../base/testHelperDeleteTestdata";
+import { generateRolleName } from "../base/testHelperGenerateTestdataNames";
 
 const PW = process.env.PW;
 const ADMIN = process.env.USER;
@@ -72,7 +73,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
     const vorname = "TAuto-PW-V-" + faker.person.firstName();
     const nachname = "TAuto-PW-N-" + faker.person.lastName();
     const organisation = 'Land Schleswig-Holstein';
-    const rollenname = 'TAuto-PW-R-RolleLandesadmin';
+    const rollenname = generateRolleName();
     const rollenart = 'SYSADMIN'
 
     await test.step(`Landesadmin via api anlegen und mit diesem anmelden`, async () => {
@@ -140,7 +141,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
     const nachname = "TAuto-PW-N-" + faker.person.lastName();
     const organisation = 'Testschule Schulportal';
     const dienststellenNr = '1111111';
-    const rollenname = 'TAuto-PW-R-RolleLehrer';
+    const rollenname =  generateRolleName();
     const rollenart = 'LEHR';
 
     await test.step(`Lehrer via api anlegen und mit diesem anmelden`, async () => {
@@ -198,7 +199,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
     const nachname = "TAuto-PW-N-" + faker.person.lastName();
     const organisation = 'Testschule Schulportal';
     const dienststellenNr = '1111111';
-    const rollenname = 'TAuto-PW-R-RolleSchüler';
+    const rollenname =  generateRolleName();
     const rollenart = 'LERN';
 
     await test.step(`Lehrer via api anlegen und mit diesem anmelden`, async () => {
@@ -255,7 +256,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
     const nachname = "TAuto-PW-N-" + faker.person.lastName();
     const organisation = 'Testschule Schulportal';
     const dienststellenNr = '1111111';
-    const rollenname = 'TAuto-PW-R-RolleSchuladmin';
+    const rollenname =  generateRolleName();
     const rollenart = 'LEIT'
 
     await test.step(`Lehrer via api anlegen und mit diesem anmelden`, async () => {
@@ -316,7 +317,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
     const organisation2 = 'Carl-Orff-Schule';
     const dienststellenNr1 = '1111111';
     const dienststellenNr2 = '0702948';
-    const rollenname = 'TAuto-PW-R-RolleLehrer';
+    const rollenname =  generateRolleName();
     const rollenart = 'LEHR';
 
     await test.step(`Lehrer via api anlegen und mit diesem anmelden`, async () => {
@@ -383,7 +384,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
     const vorname = "TAuto-PW-V-" + faker.person.firstName();
     const nachname = "TAuto-PW-N-" + faker.person.lastName();
     const organisation = 'Testschule Schulportal';
-    const rollenname = 'TAuto-PW-R-RolleSchüler';
+    const rollenname =  generateRolleName();
     const rollenart = 'LERN';
 
     await test.step(`Lehrer via api anlegen und mit diesem anmelden`, async () => {

--- a/tests/Schule.spec.ts
+++ b/tests/Schule.spec.ts
@@ -14,6 +14,7 @@ import { addSystemrechtToRolle } from "../base/api/testHelperRolle.page";
 import { FooterDataTablePage } from "../pages/FooterDataTable.page";
 import { LONG, SHORT, STAGE } from "../base/tags";
 import { deletePersonById, deleteRolleById } from "../base/testHelperDeleteTestdata";
+import { generateRolleName } from "../base/testHelperGenerateTestdataNames";
 
 const PW = process.env.PW;
 const ADMIN = process.env.USER;
@@ -149,7 +150,7 @@ test.describe(`Testfälle für die Administration von Schulen: Umgebung: ${proce
 
     const startseite: StartPage = await test.step(`Testdaten: Schuladmin anlegen und mit diesem anmelden`, async () => {
       const idSP = await getSPId(page, 'Schulportal-Administration');
-      userInfo = await createRolleAndPersonWithUserContext(page, 'Testschule Schulportal', 'LEIT', 'TAuto-PW-B-MeierLEIT', 'TAuto-PW-B-Hans', idSP, 'TAuto-PW-R-RolleLEIT');
+      userInfo = await createRolleAndPersonWithUserContext(page, 'Testschule Schulportal', 'LEIT', 'TAuto-PW-B-MeierLEIT', 'TAuto-PW-B-Hans', idSP, generateRolleName());
       personId.push(userInfo.personId);
       roleId.push(userInfo.rolleId);
       await addSystemrechtToRolle(page, userInfo.rolleId, 'SCHULEN_VERWALTEN');

--- a/tests/SchulportalAdministration.spec.ts
+++ b/tests/SchulportalAdministration.spec.ts
@@ -9,6 +9,7 @@ import { addSystemrechtToRolle } from "../base/api/testHelperRolle.page";
 import { UserInfo } from "../base/api/testHelper.page";
 import { LONG, SHORT, STAGE } from "../base/tags";
 import { deletePersonById, deleteRolleById } from "../base/testHelperDeleteTestdata";
+import { generateRolleName } from "../base/testHelperGenerateTestdataNames";
 
 const PW = process.env.PW;
 const ADMIN = process.env.USER;
@@ -60,7 +61,7 @@ test.describe(`Testfälle für Schulportal Administration": Umgebung: ${process.
         await login.login(ADMIN, PW);
 
         const idSP = await getSPId(page, 'E-Mail');
-        const userInfo: UserInfo = await createRolleAndPersonWithUserContext(page, 'Testschule Schulportal', 'LEHR', 'TAuto-PW-B-MeierLehrer', 'TAuto-PW-B-Hans', idSP, 'TAuto-PW-R-RolleLehrer');
+        const userInfo: UserInfo = await createRolleAndPersonWithUserContext(page, 'Testschule Schulportal', 'LEHR', 'TAuto-PW-B-MeierLehrer', 'TAuto-PW-B-Hans', idSP, generateRolleName());
         personId.push(userInfo.personId); 
         rolleId.push(userInfo.rolleId);
         await header.logout();
@@ -87,7 +88,7 @@ test.describe(`Testfälle für Schulportal Administration": Umgebung: ${process.
         await login.login(ADMIN, PW);
 
         const idSP = await getSPId(page, 'itslearning');
-        const userInfo: UserInfo = await createRolleAndPersonWithUserContext(page, 'Testschule Schulportal', 'LERN', 'TAuto-PW-B-JansenSchüler', 'TAuto-PW-B-Helga', idSP, 'TAuto-PW-R-RolleSuS');
+        const userInfo: UserInfo = await createRolleAndPersonWithUserContext(page, 'Testschule Schulportal', 'LERN', 'TAuto-PW-B-JansenSchüler', 'TAuto-PW-B-Helga', idSP, generateRolleName());
         personId.push(userInfo.personId); 
         rolleId.push(userInfo.rolleId);
         await header.logout();
@@ -114,7 +115,7 @@ test.describe(`Testfälle für Schulportal Administration": Umgebung: ${process.
         await login.login(ADMIN, PW);
 
         const idSP = await getSPId(page, 'Schulportal-Administration');
-        const userInfo: UserInfo = await createRolleAndPersonWithUserContext(page, 'Testschule Schulportal', 'LEIT', 'TAuto-PW-B-MeierAdmin', 'TAuto-PW-B-Peter', idSP, 'TAuto-PW-R-RolleSchuladmin');
+        const userInfo: UserInfo = await createRolleAndPersonWithUserContext(page, 'Testschule Schulportal', 'LEIT', 'TAuto-PW-B-MeierAdmin', 'TAuto-PW-B-Peter', idSP, generateRolleName());
         personId.push(userInfo.personId); 
         rolleId.push(userInfo.rolleId);
 

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -10,6 +10,7 @@ import { faker } from "@faker-js/faker/locale/de";
 import { UserInfo } from "../base/api/testHelper.page.ts";
 import { deletePersonByUsername, deleteRolleById } from "../base/testHelperDeleteTestdata.ts";
 import { getOrganisationId } from "../base/api/testHelperOrganisation.page.ts";
+import { generateRolleName } from '../base/testHelperGenerateTestdataNames.ts';
 
 const PW = process.env.PW;
 const ADMIN = process.env.USER;
@@ -108,7 +109,7 @@ test.describe(`Testfälle für die Authentifizierung: Umgebung: ${process.env.UM
 
     const lehrerVorname = "TAuto-PW-V-" + faker.person.firstName();
     const lehrerNachname = "TAuto-PW-N-" + faker.person.lastName();
-    const lehrerRolle = "TAuto-PW-LEHR-" + faker.lorem.word({ length: { min: 8, max: 12 }});
+    const lehrerRolle = generateRolleName();
     const lehrerRollenart = 'LEHR';
     const lehrerOrganisation = 'Testschule Schulportal';
     let userInfoLehrer: UserInfo;


### PR DESCRIPTION
# Description
- Bei der Anlage der Rollen wird immer einen neuen Rollennamen erzeugt.
- Die Methode generateRolleName() in testHelperGenerateTestdataNames wird verwendet.

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/SPSH-1359

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.