### PR TITLE
SPSH-1375: Fixed the flaky test by selecting another locator.

### DIFF
--- a/pages/admin/PersonCreationView.page.ts
+++ b/pages/admin/PersonCreationView.page.ts
@@ -34,6 +34,7 @@ export class PersonCreationViewPage{
     readonly data_Organisationsebene: Locator;
     readonly label_Klasse: Locator;
     readonly data_Klasse: Locator;
+    readonly listbox_Rolle: Locator;
    
     constructor(page){
         // Anlage Person
@@ -70,5 +71,6 @@ export class PersonCreationViewPage{
         this.input_EinstiegsPasswort = page.locator('[data-testid="password-output-field"] input'); 
         this.button_ZurueckErgebnisliste = page.getByTestId('back-to-list-button');
         this.button_WeiterenBenutzerAnlegen = page.getByTestId('create-another-person-button');
+        this.listbox_Rolle = page.locator('.v-list');
     }
 }

--- a/tests/Person.spec.ts
+++ b/tests/Person.spec.ts
@@ -352,11 +352,11 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       await page.getByText(Organisation_Land, { exact: true }).nth(1).click();
 
       await personCreationView.combobox_Rolle.click();
-      await expect(personCreationView.body).toContainText(landesadminRolle);
-      await expect(personCreationView.body).not.toContainText(rolleLehr);
-      await expect(personCreationView.body).not.toContainText(rolleLiV);
-      await expect(personCreationView.body).not.toContainText(schuladminOeffentlichRolle);
-      await expect(personCreationView.body).not.toContainText(schuelerRolle);
+      await expect(personCreationView.listbox_Rolle).toContainText(landesadminRolle);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(rolleLehr);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(rolleLiV);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(schuladminOeffentlichRolle);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(schuelerRolle);
     });
 
     await test.step(`Organisation 'Öffentliche Schulen Land Schleswig-Holstein' auswählen und Dropdown 'Rolle' prüfen`, async () => {
@@ -365,11 +365,11 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       await page.keyboard.type(Organisation_OeffentlicheSchule);
       await page.getByText(Organisation_OeffentlicheSchule, { exact: true }).click();
       await personCreationView.combobox_Rolle.click();
-      await expect(personCreationView.body).toContainText(landesadminRolle);
-      await expect(personCreationView.body).not.toContainText(rolleLehr);
-      await expect(personCreationView.body).not.toContainText(rolleLiV);
-      await expect(personCreationView.body).not.toContainText(schuladminOeffentlichRolle);
-      await expect(personCreationView.body).not.toContainText(schuelerRolle);
+      await expect(personCreationView.listbox_Rolle).toContainText(landesadminRolle);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(rolleLehr);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(rolleLiV);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(schuladminOeffentlichRolle);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(schuelerRolle);
     });
 
     await test.step(`Organisation 'Ersatzschulen Land Schleswig-Holstein' auswählen und Dropdown 'Rolle' prüfen`, async () => {
@@ -378,11 +378,11 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       await page.keyboard.type(Organisation_Ersatzschule);
       await page.getByText(Organisation_Ersatzschule, { exact: true }).click();
       await personCreationView.combobox_Rolle.click();
-      await expect(personCreationView.body).toContainText(landesadminRolle);
-      await expect(personCreationView.body).not.toContainText(rolleLehr);
-      await expect(personCreationView.body).not.toContainText(rolleLiV);
-      await expect(personCreationView.body).not.toContainText(schuladminOeffentlichRolle);
-      await expect(personCreationView.body).not.toContainText(schuelerRolle);
+      await expect(personCreationView.listbox_Rolle).toContainText(landesadminRolle);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(rolleLehr);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(rolleLiV);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(schuladminOeffentlichRolle);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(schuelerRolle);
     });
 
     await test.step(`Organisation 'Schule' auswählen und Dropdown 'Rolle' prüfen`, async () => {
@@ -390,11 +390,11 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       await personCreationView.combobox_Schulstrukturknoten.click();
       await page.getByText(Organisation_Schule).click();
       await personCreationView.combobox_Rolle.click();
-      await expect(personCreationView.body).toContainText(rolleLehr);
-      await expect(personCreationView.body).toContainText(rolleLiV);
-      await expect(personCreationView.body).toContainText(schuladminOeffentlichRolle);
-      await expect(personCreationView.body).toContainText(schuelerRolle);
-      await expect(personCreationView.body).not.toContainText(landesadminRolle);
+      await expect(personCreationView.listbox_Rolle).toContainText(rolleLehr);
+      await expect(personCreationView.listbox_Rolle).toContainText(rolleLiV);
+      await expect(personCreationView.listbox_Rolle).toContainText(schuladminOeffentlichRolle);
+      await expect(personCreationView.listbox_Rolle).toContainText(schuelerRolle);
+      await expect(personCreationView.listbox_Rolle).not.toContainText(landesadminRolle);
     });
   });
 


### PR DESCRIPTION
# Description
Test fix for the flaky tests failing due to to the autocomplete dropdown for the Rolle

## Links to Tickets or other PRs
https://ticketsystem.dbildungscloud.de/browse/SPSH-1375

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.