### PR TITLE
SPSH-1636 fix

### DIFF
--- a/tests/Klasse.spec.ts
+++ b/tests/Klasse.spec.ts
@@ -187,7 +187,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
       await klasseManagementView.checkTableData();
     });
   });
-  test('Klasse bearbeiten als Landesadmin', { tag: [LONG, SHORT, STAGE] }, async ({ page }) => {
+  test('Klasse bearbeiten als Landesadmin', { tag: [LONG] }, async ({ page }) => {
     const header = new HeaderPage(page);
     const landing: LandingPage = new LandingPage(page);
     const login: LoginPage = new LoginPage(page);
@@ -261,7 +261,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
       className.push(klassenname);
     });
   });
-  test('Klasse bearbeiten als Schuladmin', { tag: [LONG, SHORT, STAGE] }, async ({ page }) => {
+  test('Klasse bearbeiten als Schuladmin', { tag: [LONG] }, async ({ page }) => {
     const header = new HeaderPage(page);
     const landing: LandingPage = new LandingPage(page);
     const login: LoginPage = new LoginPage(page);


### PR DESCRIPTION
Die Tests
Klasse bearbeiten als Landesadmin
Klasse bearbeiten als Schuladmin
sind jetzt nur in der testsuite long um die pipeline/merging nicht zu behindern