### PR TITLE
Spsh 1911 befristung schulzuordnung bearbeiten

### DIFF
--- a/base/api/testHelperPerson.page.ts
+++ b/base/api/testHelperPerson.page.ts
@@ -193,3 +193,29 @@ export async function lockPerson(page: Page, personId: string, organisationId: s
   });
   expect(response.status()).toBe(202);
 }
+
+export async function setTimeLimitPersonenkontext(
+  page: Page,
+  personId: string,
+  organisationId1: string,
+  rolleId: string,
+  timeLimit: string,
+) {
+  const response = await page.request.put(FRONTEND_URL + 'api/personenkontext-workflow/' + personId, {
+    data: {
+      lastModified: '2034-09-11T08:28:36.590Z',
+      count: 1,
+      personenkontexte: [
+        {
+          befristung: timeLimit,
+          personId: personId,
+          organisationId: organisationId1,
+          rolleId: rolleId,
+        },
+      ],
+    },
+    failOnStatusCode: false,
+    maxRetries: 3,
+  });
+  expect(response.status()).toBe(200);
+}

--- a/base/api/testHelperPerson.page.ts
+++ b/base/api/testHelperPerson.page.ts
@@ -16,7 +16,6 @@ import { testschuleName } from '../organisation';
 import { email, kalender, adressbuch } from '../sp';
 import { typeLehrer } from '../rollentypen';
 import { generateCurrentDate } from '../../base/testHelperUtils';
-import { da } from '@faker-js/faker';
 
 const FRONTEND_URL: string | undefined = process.env.FRONTEND_URL || '';
 
@@ -104,11 +103,11 @@ export async function createRolleAndPersonWithUserContext(
   rolleName: string,
   koPersNr?: string,
   klasseId?: string,
-  merkmalName?: string[]
+  merkmaleName?: string[]
 ): Promise<UserInfo> {
   // Organisation wird nicht angelegt, da diese zur Zeit nicht gelöscht werden kann
   const organisationId: string = await getOrganisationId(page, organisationName);
-  const rolleId: string = await createRolle(page, rollenArt, organisationId, rolleName, merkmalName);
+  const rolleId: string = await createRolle(page, rollenArt, organisationId, rolleName, merkmaleName);
 
   await addSPToRolle(page, rolleId, idSPs);
   const userInfo: UserInfo = await createPerson(
@@ -119,7 +118,7 @@ export async function createRolleAndPersonWithUserContext(
     rolleId,
     koPersNr,
     klasseId,
-    merkmalName
+    merkmaleName
   );
   return userInfo;
 }

--- a/base/api/testHelperPerson.page.ts
+++ b/base/api/testHelperPerson.page.ts
@@ -209,7 +209,7 @@ export async function lockPerson(page: Page, personId: string, organisationId: s
 export async function setTimeLimitPersonenkontext(
   page: Page,
   personId: string,
-  organisationId1: string,
+  organisationId: string,
   rolleId: string,
   timeLimit: string
 ) {
@@ -221,7 +221,7 @@ export async function setTimeLimitPersonenkontext(
         {
           befristung: timeLimit,
           personId: personId,
-          organisationId: organisationId1,
+          organisationId: organisationId,
           rolleId: rolleId,
         },
       ],

--- a/base/api/testHelperRolle.page.ts
+++ b/base/api/testHelperRolle.page.ts
@@ -9,7 +9,20 @@ export async function createRolle(
   rolleName: string,
   merkmalelName?: string[]
 ): Promise<string> {
-  let requestData: any;
+  let requestData: RolleRequestData;
+
+  type RolleRequestData = {
+    data: {
+      name: string;
+      administeredBySchulstrukturknoten: string;
+      rollenart: string;
+      systemrechte: string[];
+      version: number;
+      merkmale?: string[];
+    };
+    failOnStatusCode: boolean;
+    maxRetries: number;
+  }
 
   requestData = {
     data: {

--- a/base/api/testHelperRolle.page.ts
+++ b/base/api/testHelperRolle.page.ts
@@ -1,58 +1,79 @@
 import { Page, expect } from '@playwright/test';
 
-const FRONTEND_URL: string | undefined = process.env.FRONTEND_URL || "";
+const FRONTEND_URL: string | undefined = process.env.FRONTEND_URL || '';
 
-export async function createRolle(page: Page, rollenArt: string, organisationId: string, rolleName?: string): Promise<string> {
-    const response = await page.request.post(FRONTEND_URL + 'api/rolle/', {
-        data: {
-            "name": rolleName,
-            "administeredBySchulstrukturknoten": organisationId,
-            "rollenart": rollenArt,
-            "merkmale": [],
-            "systemrechte": [],
-            "version": 1,
-        },
-        failOnStatusCode: false, 
-        maxRetries: 3
-    });
-    expect(response.status()).toBe(201);
-    const json = await response.json();
-    return json.id;
+export async function createRolle(
+  page: Page,
+  rollenArt: string,
+  organisationId: string,
+  rolleName: string,
+  merkmalelName?: string[]
+): Promise<string> {
+  let requestData: any;
+
+  requestData = {
+    data: {
+      name: rolleName,
+      administeredBySchulstrukturknoten: organisationId,
+      rollenart: rollenArt,
+      systemrechte: [],
+      version: 1,
+    },
+    failOnStatusCode: false,
+    maxRetries: 3,
+  };
+
+  if (merkmalelName) {
+    requestData.data['merkmale'] = merkmalelName;
+  } else {
+    requestData.data['merkmale'] = [];
+  }
+
+  const response = await page.request.post(FRONTEND_URL + 'api/rolle/', requestData);
+  expect(response.status()).toBe(201);
+  const json = await response.json();
+  return json.id;
 }
 
-export async function addSPToRolle(page: Page, rolleId: string, idSPs: string[]): Promise<void> { 
-    const response = await page.request.put(FRONTEND_URL + `api/rolle/${rolleId}/serviceProviders`, {
-        data: {
-            "serviceProviderIds": idSPs,
-            "version": 1,
-        },
-        failOnStatusCode: false,
-        maxRetries: 3
-    });
+export async function addSPToRolle(page: Page, rolleId: string, idSPs: string[]): Promise<void> {
+  const response = await page.request.put(FRONTEND_URL + `api/rolle/${rolleId}/serviceProviders`, {
+    data: {
+      serviceProviderIds: idSPs,
+      version: 1,
+    },
+    failOnStatusCode: false,
+    maxRetries: 3,
+  });
 
-    expect(response.status()).toBe(201);
+  expect(response.status()).toBe(201);
 }
 
 export async function addSystemrechtToRolle(page: Page, rolleId: string, systemrecht: string): Promise<void> {
-    const response = await page.request.patch(FRONTEND_URL + `api/rolle/${rolleId}`, {
-        data: {
-            "systemRecht": systemrecht,
-            "version": 1,
-        },
-        failOnStatusCode: false, 
-        maxRetries: 3
-    });
-    expect(response.status()).toBe(200);
+  const response = await page.request.patch(FRONTEND_URL + `api/rolle/${rolleId}`, {
+    data: {
+      systemRecht: systemrecht,
+      version: 1,
+    },
+    failOnStatusCode: false,
+    maxRetries: 3,
+  });
+  expect(response.status()).toBe(200);
 }
 
 export async function deleteRolle(page: Page, RolleId: string): Promise<void> {
-    const response = await page.request.delete(FRONTEND_URL + `api/rolle/${RolleId}`, {failOnStatusCode: false, maxRetries: 3});
-    expect(response.status()).toBe(204);
+  const response = await page.request.delete(FRONTEND_URL + `api/rolle/${RolleId}`, {
+    failOnStatusCode: false,
+    maxRetries: 3,
+  });
+  expect(response.status()).toBe(204);
 }
 
 export async function getRolleId(page: Page, Rollenname: string): Promise<string> {
-    const response = await page.request.get(FRONTEND_URL + `api/rolle?searchStr=${Rollenname}`, {failOnStatusCode: false, maxRetries: 3});  
-    expect(response.status()).toBe(200); 
-    const json = await response.json(); 
-    return json[0].id;
+  const response = await page.request.get(FRONTEND_URL + `api/rolle?searchStr=${Rollenname}`, {
+    failOnStatusCode: false,
+    maxRetries: 3,
+  });
+  expect(response.status()).toBe(200);
+  const json = await response.json();
+  return json[0].id;
 }

--- a/base/merkmale.ts
+++ b/base/merkmale.ts
@@ -1,0 +1,2 @@
+export const befristungPflicht: string = 'BEFRISTUNG_PFLICHT';
+export const kopersNrPflicht: string = 'KOPERS_PFLICHT';

--- a/base/organisation.ts
+++ b/base/organisation.ts
@@ -1,5 +1,7 @@
-export const testschule = "Testschule Schulportal";
-export const testschule665 = "Testschule-PW665";
-export const landSH = "Land Schleswig-Holstein";
-export const ersatzLandSH = "Ersatzschulen Land Schleswig-Holstein";
-export const oeffentlichLandSH = "Öffentliche Schulen Land Schleswig-Holstein";
+export const testschuleName = 'Testschule Schulportal';
+export const testschuleDstNr = '1111111';
+export const testschule665Name = "Testschule-PW665";
+export const testschule665DstNr = '1111165';
+export const landSH = 'Land Schleswig-Holstein';
+export const ersatzLandSH = 'Ersatzschulen Land Schleswig-Holstein';
+export const oeffentlichLandSH = 'Öffentliche Schulen Land Schleswig-Holstein';

--- a/base/rollentypen.ts
+++ b/base/rollentypen.ts
@@ -1,4 +1,4 @@
-export const typeLandesadmin: string = "SYSADMIN";
-export const typeLehrer: string = "LEHR";
-export const typeSchueler: string = "LERN";
-export const typeSchuladmin: string = "LEIT";
+export const typeLandesadmin: string = 'SYSADMIN';
+export const typeLehrer: string = 'LEHR';
+export const typeSchueler: string = 'LERN';
+export const typeSchuladmin: string = 'LEIT';

--- a/base/testHelperGenerateTestdataNames.ts
+++ b/base/testHelperGenerateTestdataNames.ts
@@ -1,30 +1,50 @@
 import { faker } from '@faker-js/faker/locale/de';
-import { generateRandomString, CharacterSetType } from 'ts-randomstring/lib/index.js'
+import { generateRandomString, CharacterSetType } from 'ts-randomstring/lib/index.js';
 
-export async function generateVorname(){  
-  return "TAuto-PW-V-" + faker.person.firstName() + generateRandomString({length: 3,charSetType: CharacterSetType.Alphabetic})
+export async function generateVorname(): Promise<string> {
+  return (
+    'TAuto-PW-V-' +
+    faker.person.firstName() +
+    generateRandomString({ length: 3, charSetType: CharacterSetType.Alphabetic })
+  );
 }
 
-export async function generateNachname(){  
-  return "TAuto-PW-N-" + faker.person.lastName() + generateRandomString({length: 3,charSetType: CharacterSetType.Alphabetic})
+export async function generateNachname(): Promise<string> {
+  return (
+    'TAuto-PW-N-' +
+    faker.person.lastName() +
+    generateRandomString({ length: 3, charSetType: CharacterSetType.Alphabetic })
+  );
 }
 
-export async function generateRolleName(){  
-  return "TAuto-PW-R-" + faker.lorem.word({ length: { min: 7, max: 7 }}) + generateRandomString({length: 3,charSetType: CharacterSetType.Alphabetic});
+export async function generateRolleName(): Promise<string> {
+  return (
+    'TAuto-PW-R-' +
+    faker.lorem.word({ length: { min: 7, max: 7 } }) +
+    generateRandomString({ length: 3, charSetType: CharacterSetType.Alphabetic })
+  );
 }
 
-export async function generateKopersNr(){  
+export async function generateKopersNr(): Promise<string> {
   return '0815' + faker.string.numeric({ length: 8 });
 }
 
-export async function generateKlassenname(){  
-  return "TAuto-PW-K-12a " + faker.lorem.word({ length: { min: 8, max: 8 }}) + generateRandomString({length: 3,charSetType: CharacterSetType.Alphabetic});
+export async function generateKlassenname(): Promise<string> {
+  return (
+    'TAuto-PW-K-12a ' +
+    faker.lorem.word({ length: { min: 8, max: 8 } }) +
+    generateRandomString({ length: 3, charSetType: CharacterSetType.Alphabetic })
+  );
 }
 
-export async function generateSchulname(){  
-  return "TAuto-PW-S-" + faker.lorem.word({ length: { min: 8, max: 8 }}) + generateRandomString({length: 3,charSetType: CharacterSetType.Alphabetic});
+export async function generateSchulname(): Promise<string> {
+  return (
+    'TAuto-PW-S-' +
+    faker.lorem.word({ length: { min: 8, max: 8 } }) +
+    generateRandomString({ length: 3, charSetType: CharacterSetType.Alphabetic })
+  );
 }
 
-export async function generateDienststellenNr(){  
-  return "0" + faker.number.bigInt({ min: 10000000, max: 100000000 });
+export async function generateDienststellenNr(): Promise<string> {
+  return '0' + faker.number.bigInt({ min: 10000000, max: 100000000 });
 }

--- a/base/testHelperUtils.ts
+++ b/base/testHelperUtils.ts
@@ -1,13 +1,17 @@
-import  moment from 'moment';
+import moment from 'moment';
 
-export async function gotoTargetURL(page, target: string) {  
+export async function gotoTargetURL(page, target: string) {
   await page.goto(target);
 }
 
-export async function generateDateToday() {  
+export async function generateDateToday() {
   return moment().format('DD.MM.YYYY');
 }
 
-export async function generateDateFuture(days: number, months: number) {  
-  return moment().add({ days: days, months: months }).format('DD.MM.YYYY');
+export async function generateDate(days: number, months: number, formatYMD?: boolean) {
+  if (formatYMD) {
+    return moment().add({ days: days, months: months }).format('YYYY.MM.DD');
+  } else {
+    return moment().add({ days: days, months: months }).format('DD.MM.YYYY');
+  }
 }

--- a/base/testHelperUtils.ts
+++ b/base/testHelperUtils.ts
@@ -1,15 +1,25 @@
-import moment from 'moment';
+import { format, addDays, addMonths } from 'date-fns';
 
 export async function gotoTargetURL(page, target: string) {
   await page.goto(target);
 }
 
-export async function generateCurrentDate({ days, months, formatDMY }: { days: number; months: number; formatDMY: boolean }) {
+export async function generateCurrentDate({
+  days,
+  months,
+  formatDMY,
+}: {
+  days: number;
+  months: number;
+  formatDMY: boolean;
+}) {
   // creates current date and adds days + month to the current date
   // returned format is DD.MM.YYYY or YYYY.MM.DD
+  const newDate: Date = addDays(addMonths(new Date(), months), days);
+
   if (formatDMY) {
-    return moment().add({ days: days, months: months }).format('DD.MM.YYYY');
+    return format(newDate, 'dd.MM.yyyy');
   } else {
-    return moment().add({ days: days, months: months }).format('YYYY.MM.DD');
+    return format(newDate, 'yyyy.MM.dd');
   }
 }

--- a/base/testHelperUtils.ts
+++ b/base/testHelperUtils.ts
@@ -4,14 +4,12 @@ export async function gotoTargetURL(page, target: string) {
   await page.goto(target);
 }
 
-export async function generateDateToday() {
-  return moment().format('DD.MM.YYYY');
-}
-
-export async function generateDate(days: number, months: number, formatYMD?: boolean) {
-  if (formatYMD) {
-    return moment().add({ days: days, months: months }).format('YYYY.MM.DD');
-  } else {
+export async function generateCurrentDate({ days, months, formatDMY }: { days: number; months: number; formatDMY: boolean }) {
+  // creates current date and adds days + month to the current date
+  // returned format is DD.MM.YYYY or YYYY.MM.DD
+  if (formatDMY) {
     return moment().add({ days: days, months: months }).format('DD.MM.YYYY');
+  } else {
+    return moment().add({ days: days, months: months }).format('YYYY.MM.DD');
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,14 @@
         "@faker-js/faker": "^8.4.1",
         "@fast-csv/format": "^4.3.5",
         "@fast-csv/parse": "^4.3.6",
+        "date-fns": "^4.1.0",
         "fast-csv": "^4.3.6",
         "generate-password-ts": "^1.6.5",
         "moment": "^2.30.1",
         "ts-randomstring": "^1.0.8"
       },
       "devDependencies": {
-        "@playwright/test": "^1.50.0",
+        "@playwright/test": "^1.50.1",
         "@types/node": "^20.16.10",
         "@typescript-eslint/eslint-plugin": "^8.8.0",
         "@typescript-eslint/parser": "^8.8.0",
@@ -617,6 +618,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@faker-js/faker": "^8.4.1",
     "@fast-csv/format": "^4.3.5",
     "@fast-csv/parse": "^4.3.6",
+    "date-fns": "^4.1.0",
     "fast-csv": "^4.3.6",
     "generate-password-ts": "^1.6.5",
     "moment": "^2.30.1",

--- a/pages/StartView.page.ts
+++ b/pages/StartView.page.ts
@@ -42,7 +42,7 @@ export class StartPage {
   }
 
   public async checkSpIsVisible(spNames: string[]) {
-    for (let spName of spNames) {
+    for (const spName of spNames) {
       await expect(this.cardItem(spName)).toBeVisible();
     }
   }

--- a/pages/admin/PersonDetailsView.page.ts
+++ b/pages/admin/PersonDetailsView.page.ts
@@ -36,6 +36,11 @@ export class PersonDetailsViewPage {
   readonly button_closeSaveAssignmentChanges: Locator;
   readonly button_befristetSchuljahresende: Locator;
   readonly button_befristungUnbefristet: Locator;
+  readonly buttonBefristungAendern: Locator;
+  readonly inputBefristung: Locator;
+  readonly errorTextInputBefristung: Locator;
+  readonly radioButtonBefristungSchuljahresende: Locator;
+  readonly radioButtonUnbefristet: Locator;
 
   readonly organisationen: ComboBox;
   readonly organisationenInput: ComboBox;
@@ -120,6 +125,11 @@ export class PersonDetailsViewPage {
     this.organisationen = new ComboBox(this.page, this.combobox_organisation);
     this.organisationenInput = new ComboBox(this.page, this.comboboxOrganisationInput);
     this.rollen = new ComboBox(this.page, this.combobox_rolle);
+    this.buttonBefristungAendern = page.getByTestId('befristung-change-button');
+    this.inputBefristung = page.locator('[data-testid="befristung-input"] input');
+    this.errorTextInputBefristung = page.getByText('Das eingegebene Datum darf nicht in der Vergangenheit liegen.');
+    this.radioButtonBefristungSchuljahresende = page.getByTestId('schuljahresende-radio-button');
+    this.radioButtonUnbefristet = page.getByTestId('unbefristet-radio-button');
 
     // Benutzer sperren
     this.text_h3_lockPerson_headline = page.getByTestId('person-lock-info').getByText('Status');

--- a/pages/admin/PersonDetailsView.page.ts
+++ b/pages/admin/PersonDetailsView.page.ts
@@ -225,7 +225,7 @@ export class PersonDetailsViewPage {
     await expect(this.selectOption_2FA_softwareToken).toHaveText('Software-Token einrichten');
     await expect(this.text_2FA_softwareToken_info).toBeVisible();
     await this.button_2FA_Einrichten_Weiter.click();
-    await this.teardownAPI({ lastEndpoint: '2fa-token/**/' });
+    await this.waitForAPIResponse({ lastEndpoint: '2fa-token/**/' });
     await expect(this.text_h2_2FA_cardheadline).toHaveText('Software-Token einrichten');
     await this.button_close_softwareToken_dialog.click();
   }
@@ -233,7 +233,7 @@ export class PersonDetailsViewPage {
   public async createIbnPassword(): Promise<void> {
     await this.buttonIBNPasswortEinrichtenDialog.click();
     await this.buttonIBNPasswortEinrichten.click();
-    await this.teardownAPI({ lastEndpoint: 'personen/**/uem-password' });
+    await this.waitForAPIResponse({ lastEndpoint: 'personen/**/uem-password' });
     await expect(this.infoIBNPasswortEinrichten).toContainText('Das Passwort wurde erfolgreich erzeugt.');
     await this.buttonIBNPasswortEinrichtenDialogClose.click();
     await expect(this.text_h2_benutzerBearbeiten).toHaveText('Benutzer bearbeiten');
@@ -253,7 +253,7 @@ export class PersonDetailsViewPage {
     ).toHaveCSS('color', textColor);
   }
 
-  public async teardownAPI({ lastEndpoint }: { lastEndpoint: string }): Promise<void> {
+  public async waitForAPIResponse({ lastEndpoint }: { lastEndpoint: string }): Promise<void> {
     await this.page.waitForResponse('/api/' + lastEndpoint);
   }
 }

--- a/pages/admin/PersonDetailsView.page.ts
+++ b/pages/admin/PersonDetailsView.page.ts
@@ -1,6 +1,5 @@
 import { type Locator, Page, expect } from '@playwright/test';
 import { ComboBox } from '../../elements/ComboBox';
-import { ur } from '@faker-js/faker';
 
 export class PersonDetailsViewPage {
   readonly page: Page;

--- a/pages/admin/PersonDetailsView.page.ts
+++ b/pages/admin/PersonDetailsView.page.ts
@@ -1,5 +1,6 @@
 import { type Locator, Page, expect } from '@playwright/test';
 import { ComboBox } from '../../elements/ComboBox';
+import { ur } from '@faker-js/faker';
 
 export class PersonDetailsViewPage {
   readonly page: Page;
@@ -37,10 +38,15 @@ export class PersonDetailsViewPage {
   readonly button_befristetSchuljahresende: Locator;
   readonly button_befristungUnbefristet: Locator;
   readonly buttonBefristungAendern: Locator;
+  readonly buttonBefristungAendernSubmit: Locator;
+  readonly buttonBefristungAendernConfirm: Locator;
+  readonly buttonBefristungAendernSave: Locator;
+  readonly buttonBefristungAendernSuccessClose: Locator;
   readonly inputBefristung: Locator;
   readonly errorTextInputBefristung: Locator;
   readonly radioButtonBefristungSchuljahresende: Locator;
   readonly radioButtonUnbefristet: Locator;
+  readonly radioButtonUnbefristetDisabled: Locator;
 
   readonly organisationen: ComboBox;
   readonly organisationenInput: ComboBox;
@@ -126,10 +132,15 @@ export class PersonDetailsViewPage {
     this.organisationenInput = new ComboBox(this.page, this.comboboxOrganisationInput);
     this.rollen = new ComboBox(this.page, this.combobox_rolle);
     this.buttonBefristungAendern = page.getByTestId('befristung-change-button');
+    this.buttonBefristungAendernSubmit = page.getByTestId('change-befristung-submit-button');
+    this.buttonBefristungAendernConfirm = page.getByTestId('confirm-change-befristung-button');
+    this.buttonBefristungAendernSave = page.getByTestId('zuordnung-changes-save');
+    this.buttonBefristungAendernSuccessClose = page.getByTestId('change-befristung-success-close');
     this.inputBefristung = page.locator('[data-testid="befristung-input"] input');
     this.errorTextInputBefristung = page.getByText('Das eingegebene Datum darf nicht in der Vergangenheit liegen.');
     this.radioButtonBefristungSchuljahresende = page.getByTestId('schuljahresende-radio-button');
     this.radioButtonUnbefristet = page.getByTestId('unbefristet-radio-button');
+    this.radioButtonUnbefristetDisabled = page.getByTestId('unbefristet-radio-button').getByLabel('Unbefristet');
 
     // Benutzer sperren
     this.text_h3_lockPerson_headline = page.getByTestId('person-lock-info').getByText('Status');
@@ -215,6 +226,7 @@ export class PersonDetailsViewPage {
     await expect(this.selectOption_2FA_softwareToken).toHaveText('Software-Token einrichten');
     await expect(this.text_2FA_softwareToken_info).toBeVisible();
     await this.button_2FA_Einrichten_Weiter.click();
+    await this.teardownAPI({ lastEndpoint: '2fa-token/**/' });
     await expect(this.text_h2_2FA_cardheadline).toHaveText('Software-Token einrichten');
     await this.button_close_softwareToken_dialog.click();
   }
@@ -222,8 +234,27 @@ export class PersonDetailsViewPage {
   public async createIbnPassword(): Promise<void> {
     await this.buttonIBNPasswortEinrichtenDialog.click();
     await this.buttonIBNPasswortEinrichten.click();
+    await this.teardownAPI({ lastEndpoint: 'personen/**/uem-password' });
     await expect(this.infoIBNPasswortEinrichten).toContainText('Das Passwort wurde erfolgreich erzeugt.');
     await this.buttonIBNPasswortEinrichtenDialogClose.click();
     await expect(this.text_h2_benutzerBearbeiten).toHaveText('Benutzer bearbeiten');
+  }
+
+  public async validateEntireNameSchulzuordnung(
+    dstNr: string,
+    testschuleName: string,
+    nameRolle: string,
+    textColor: string,
+    befristungLehrerRolle: string
+  ): Promise<void> {
+    await expect(
+      this.page
+        .getByTestId('person-details-card')
+        .getByText(dstNr + ' (' + testschuleName + '): ' + nameRolle + ' (befristet bis ' + befristungLehrerRolle + ')')
+    ).toHaveCSS('color', textColor);
+  }
+
+  public async teardownAPI({ lastEndpoint }: { lastEndpoint: string }): Promise<void> {
+    await this.page.waitForResponse('/api/' + lastEndpoint);
   }
 }

--- a/pages/admin/PersonManagementView.page.ts
+++ b/pages/admin/PersonManagementView.page.ts
@@ -49,9 +49,7 @@ export class PersonManagementViewPage {
   }
 
   public async searchBySuchfeld(name: string): Promise<void> {
-    await this.page.waitForResponse(response =>
-      (response.url().includes('/api/person-administration/') && (response.status() === 200) || (response.status() === 304))
-    )
+    await this.page.waitForResponse('/api/dbiam/personenuebersicht');
     await this.input_Suchfeld.fill(name);
     await this.button_Suchen.click();
     await expect(this.comboboxMenuIcon_Status).toBeVisible();
@@ -71,7 +69,7 @@ export class PersonManagementViewPage {
   }
 
   public async waitErgebnislisteIsLoaded(): Promise<void> {
-    await this.page.waitForResponse(resp => resp.url().includes('/api/dbiam/personenuebersicht') && resp.status() === 201);
+    await this.page.waitForResponse('/api/dbiam/personenuebersicht');
     await expect(this.text_h2_Benutzerverwaltung).toContainText('Benutzerverwaltung');
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   maxFailures: 9,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: [['html']],
   use: {
     trace: 'on-first-retry',

--- a/tests/Import.spec.ts
+++ b/tests/Import.spec.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'url';
 import { deletePersonBySearchString } from '../base/testHelperDeleteTestdata.ts';
 
 // schulen cannot be deleted yet, so we use this testschule, which should already exist
-import { testschule665 } from '../base/organisation.ts';
+import { testschule665Name } from '../base/organisation.ts';
 
 const PW: string = process.env.PW as string;
 const ADMIN: string = process.env.USER as string;
@@ -62,7 +62,7 @@ test.describe(`Testfälle für den Benutzerimport": Umgebung: ${process.env.ENV}
     async ({ page }: PlaywrightTestArgs) => {
       await test.step('CSV-Datei hochladen, importieren und importierte Daten downloaden', async () => {
         // select schule
-        await personImportPage.schuleSelectCombobox.searchByTitle(testschule665, false);
+        await personImportPage.schuleSelectCombobox.searchByTitle(testschule665Name, false);
 
         // select rolle
         await personImportPage.rolleSelectInput.click();

--- a/tests/Klasse.spec.ts
+++ b/tests/Klasse.spec.ts
@@ -3,7 +3,7 @@ import { UserInfo } from '../base/api/testHelper.page.ts';
 import { createRolleAndPersonWithUserContext } from '../base/api/testHelperPerson.page.ts';
 import { addSystemrechtToRolle } from '../base/api/testHelperRolle.page.ts';
 import { getSPId } from '../base/api/testHelperServiceprovider.page.ts';
-import { landSH, testschuleName, testschuleDstNr, testschule665 } from '../base/organisation.ts';
+import { landSH, testschuleName, testschuleDstNr } from '../base/organisation.ts';
 import { BROWSER, LONG, SHORT, STAGE } from '../base/tags';
 import {
   deleteKlasseByName,

--- a/tests/Klasse.spec.ts
+++ b/tests/Klasse.spec.ts
@@ -3,7 +3,7 @@ import { UserInfo } from '../base/api/testHelper.page.ts';
 import { createRolleAndPersonWithUserContext } from '../base/api/testHelperPerson.page.ts';
 import { addSystemrechtToRolle } from '../base/api/testHelperRolle.page.ts';
 import { getSPId } from '../base/api/testHelperServiceprovider.page.ts';
-import { landSH, testschule } from '../base/organisation.ts';
+import { landSH, testschuleName, testschuleDstNr } from '../base/organisation.ts';
 import { BROWSER, LONG, SHORT, STAGE } from '../base/tags';
 import {
   deleteKlasseByName,
@@ -94,7 +94,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
       const menue: MenuPage = new MenuPage(page);
       const klasseCreationView: KlasseCreationViewPage = new KlasseCreationViewPage(page);
       const klasseManagementView: KlasseManagementViewPage = new KlasseManagementViewPage(page);
-      const schulname: string = testschule;
+      const schulname: string = testschuleName;
       const klassenname: string = await generateKlassenname();
 
       await test.step(`Dialog Klasse anlegen öffnen`, async () => {
@@ -104,7 +104,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
       });
 
       await test.step(`Klasse anlegen`, async () => {
-        await klasseCreationView.comboboxOrganisationInput.searchByTitle(testschule, false);
+        await klasseCreationView.comboboxOrganisationInput.searchByTitle(testschuleName, false);
         await klasseCreationView.inputKlassenname.fill(klassenname);
         await klasseCreationView.buttonKlasseAnlegen.click();
         await expect(klasseCreationView.textSuccess).toBeVisible();
@@ -155,8 +155,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
     { tag: [LONG, STAGE, BROWSER] },
     async ({ page }: PlaywrightTestArgs) => {
       const klasseCreationView: KlasseCreationViewPage = new KlasseCreationViewPage(page);
-      const dienststellennummer: string = '1111111';
-      const nameSchule: string = testschule;
+      const nameSchule: string = testschuleName;
       const klasseName: string = await generateKlassenname();
 
       await test.step(`Dialog Schule anlegen öffnen`, async () => {
@@ -177,7 +176,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
         await expect(klasseCreationView.iconSuccess).toBeVisible();
         await expect(klasseCreationView.textDatenGespeichert).toBeVisible();
         await expect(klasseCreationView.labelSchule).toBeVisible();
-        await expect(klasseCreationView.dataSchule).toHaveText(dienststellennummer + ' (' + nameSchule + ')');
+        await expect(klasseCreationView.dataSchule).toHaveText(testschuleDstNr + ' (' + nameSchule + ')');
         await expect(klasseCreationView.labelKlasse).toBeVisible();
         await expect(klasseCreationView.dataKlasse).toHaveText(klasseName);
         await expect(klasseCreationView.buttonWeitereKlasseAnlegen).toBeVisible();
@@ -268,7 +267,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
       await menue.menueItem_KlasseAnlegen.click();
       await expect(klasseCreationView.textH2KlasseAnlegen).toHaveText('Neue Klasse hinzufügen');
 
-      await klasseCreationView.comboboxOrganisationInput.searchByTitle(testschule, false);
+      await klasseCreationView.comboboxOrganisationInput.searchByTitle(testschuleName, false);
       await klasseCreationView.inputKlassenname.fill(klassenname);
       await klasseCreationView.buttonKlasseAnlegen.click();
       await expect(klasseCreationView.textSuccess).toBeVisible();
@@ -276,7 +275,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
 
     await test.step(`Klasse bearbeiten als Landesadmin`, async () => {
       await menue.menueItem_AlleKlassenAnzeigen.click();
-      await klasseCreationView.comboboxOrganisationInput.searchByTitle(testschule, false);
+      await klasseCreationView.comboboxOrganisationInput.searchByTitle(testschuleName, false);
       await page.getByRole('cell', { name: klassenname, exact: true }).click();
       klassenname = await generateKlassenname();
       await klasseDetailsView.klasseBearbeiten(klassenname);
@@ -303,7 +302,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
       const adminNachname: string = await generateNachname();
       const adminRolle: string = await generateRolleName();
       const adminRollenart: string = typeSchuladmin;
-      const adminOrganisation = testschule;
+      const adminOrganisation = testschuleName;
       const adminIdSPs: string[] = [await getSPId(page, 'Schulportal-Administration')];
 
       userInfoAdmin = await createRolleAndPersonWithUserContext(
@@ -335,7 +334,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
       await menue.menueItem_KlasseAnlegen.click();
       await expect(klasseCreationView.textH2KlasseAnlegen).toHaveText('Neue Klasse hinzufügen');
 
-      await expect(klasseCreationView.comboboxSchulstrukturknoten).toContainText(testschule);
+      await expect(klasseCreationView.comboboxSchulstrukturknoten).toContainText(testschuleName);
       await klasseCreationView.inputKlassenname.fill(klassenname);
       await klasseCreationView.buttonKlasseAnlegen.click();
       await expect(klasseCreationView.textSuccess).toBeVisible();
@@ -357,7 +356,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
     { tag: [LONG, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
       const klassenname: string = await generateKlassenname();
-      const idSchule: string = await getOrganisationId(page, testschule);
+      const idSchule: string = await getOrganisationId(page, testschuleName);
 
       await test.step('Klasse zum Löschen via Quickaction generieren', async () => {
         await createKlasse(page, idSchule, klassenname);
@@ -374,7 +373,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
         });
 
       await test.step(`In Ergebnisliste prüfen, dass die generierte Klasse angezeigt wird`, async () => {
-        await klasseManagementView.filterSchule(testschule);
+        await klasseManagementView.filterSchule(testschuleName);
         await klasseManagementView.checkRowExists(klassenname);
       });
 
@@ -384,7 +383,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
 
       await test.step(`In der Ergebnisliste Klasse prüfen, dass die Klasse nicht mehr existiert`, async () => {
         await klasseManagementView.waitErgebnislisteIsLoaded();
-        await klasseManagementView.filterSchule(testschule);
+        await klasseManagementView.filterSchule(testschuleName);
         await klasseManagementView.checkRowExists(klasse1Testschule);
         await klasseManagementView.checkRowNotExists(klassenname);
       });
@@ -396,7 +395,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
     { tag: [LONG, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
       const klassenname: string = await generateKlassenname();
-      const idSchule: string = await getOrganisationId(page, testschule);
+      const idSchule: string = await getOrganisationId(page, testschuleName);
       let userInfoAdmin: UserInfo;
 
       await test.step('Klasse zum Löschen via Quickaction generieren', async () => {
@@ -408,7 +407,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
         const adminNachname: string = await generateNachname();
         const adminRolleName = await generateRolleName();
         const adminRollenart: string = typeSchuladmin;
-        const adminOrganisation = testschule;
+        const adminOrganisation = testschuleName;
         const adminIdSPs: string[] = [await getSPId(page, 'Schulportal-Administration')];
 
         userInfoAdmin = await createRolleAndPersonWithUserContext(
@@ -466,7 +465,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
     { tag: [LONG, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
       const klassenname: string = await generateKlassenname();
-      const idSchule: string = await getOrganisationId(page, testschule);
+      const idSchule: string = await getOrganisationId(page, testschuleName);
       let klasseId: string;
       let userInfoSchueler: UserInfo;
 
@@ -483,7 +482,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
 
         userInfoSchueler = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           schuelerRollenart,
           schuelerVorname,
           schuelerNachname,
@@ -509,7 +508,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
         });
 
       await test.step(`In Ergebnisliste prüfen, dass die generierte Klasse angezeigt wird`, async () => {
-        await klasseManagementView.filterSchule(testschule);
+        await klasseManagementView.filterSchule(testschuleName);
         await klasseManagementView.checkRowExists(klassenname);
       });
 
@@ -519,7 +518,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
         await klasseManagementView.checkDeleteClassFailed();
         await klasseManagementView.clickButtonCloseAlert();
         await klasseManagementView.waitErgebnislisteIsLoaded();
-        await klasseManagementView.filterSchule(testschule);
+        await klasseManagementView.filterSchule(testschuleName);
         await klasseManagementView.checkRowExists(klassenname);
       });
     }
@@ -530,7 +529,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
     { tag: [LONG, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
       const klassenname: string = await generateKlassenname();
-      const idSchule: string = await getOrganisationId(page, testschule);
+      const idSchule: string = await getOrganisationId(page, testschuleName);
 
       await test.step('Klasse zum Löschen via Quickaction generieren', async () => {
         await createKlasse(page, idSchule, klassenname);
@@ -547,7 +546,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
         });
 
       await test.step(`In Ergebnisliste prüfen, dass die generierte Klasse angezeigt wird`, async () => {
-        await klasseManagementView.filterSchule(testschule);
+        await klasseManagementView.filterSchule(testschuleName);
         await klasseManagementView.checkRowExists(klassenname);
       });
 
@@ -568,7 +567,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
     { tag: [LONG, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
       const klassenname: string = await generateKlassenname();
-      const idSchule: string = await getOrganisationId(page, testschule);
+      const idSchule: string = await getOrganisationId(page, testschuleName);
       let userInfoAdmin: UserInfo;
 
       await test.step('Klasse zum Löschen via Quickaction generieren', async () => {
@@ -580,7 +579,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
         const adminNachname: string = await generateNachname();
         const adminRolleName = await generateRolleName();
         const adminRollenart: string = typeSchuladmin;
-        const adminOrganisation = testschule;
+        const adminOrganisation = testschuleName;
         const adminIdSPs: string[] = [await getSPId(page, 'Schulportal-Administration')];
 
         userInfoAdmin = await createRolleAndPersonWithUserContext(
@@ -638,7 +637,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
     { tag: [LONG, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
       const klassenname: string = await generateKlassenname();
-      const idSchule: string = await getOrganisationId(page, testschule);
+      const idSchule: string = await getOrganisationId(page, testschuleName);
       let klasseId: string;
       let userInfoSchueler: UserInfo;
 
@@ -655,7 +654,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
 
         userInfoSchueler = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           schuelerRollenart,
           schuelerVorname,
           schuelerNachname,
@@ -681,7 +680,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
         });
 
       await test.step(`In Ergebnisliste prüfen, dass die generierte Klasse angezeigt wird`, async () => {
-        await klasseManagementView.filterSchule(testschule);
+        await klasseManagementView.filterSchule(testschuleName);
         await klasseManagementView.checkRowExists(klassenname);
       });
 
@@ -691,7 +690,7 @@ test.describe(`Testfälle für die Administration von Klassen: Umgebung: ${proce
         await klasseManagementView.checkDeleteClassFailed();
         await klasseManagementView.clickButtonCloseAlert();
         await klasseManagementView.waitErgebnislisteIsLoaded();
-        await klasseManagementView.filterSchule(testschule);
+        await klasseManagementView.filterSchule(testschuleName);
         await klasseManagementView.checkRowExists(klassenname);
       });
     }

--- a/tests/Person.spec.ts
+++ b/tests/Person.spec.ts
@@ -3,7 +3,7 @@ import { UserInfo } from '../base/api/testHelper.page';
 import { createRolleAndPersonWithUserContext } from '../base/api/testHelperPerson.page';
 import { addSystemrechtToRolle } from '../base/api/testHelperRolle.page';
 import { getSPId } from '../base/api/testHelperServiceprovider.page';
-import { landSH, testschule, testschule665, oeffentlichLandSH, ersatzLandSH } from '../base/organisation.ts';
+import { landSH, testschuleName, testschule665Name, oeffentlichLandSH, ersatzLandSH, testschuleDstNr } from '../base/organisation.ts';
 import { landesadminRolle, schuelerRolle, schuladminOeffentlichRolle } from '../base/rollen.ts';
 import { BROWSER, LONG, SHORT, STAGE } from '../base/tags';
 import { deletePersonenBySearchStrings, deleteRolleById, deleteRolleByName } from '../base/testHelperDeleteTestdata.ts';
@@ -100,7 +100,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       const vorname: string = await generateVorname();
       const nachname: string = await generateNachname();
       const kopersnr: string = await generateKopersNr();
-      const schulstrukturknoten: string = testschule;
+      const schulstrukturknoten: string = testschuleName;
       let einstiegspasswort: string = '';
 
       await test.step(`Dialog Person anlegen öffnen`, async () => {
@@ -193,7 +193,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       const vorname: string = await generateVorname();
       const nachname: string = await generateNachname();
       const kopersnr: string = await generateKopersNr();
-      const schulstrukturknoten: string = testschule;
+      const schulstrukturknoten: string = testschuleName;
 
       await test.step(`Dialog Person anlegen öffnen`, async () => {
         await startseite.cardItemSchulportalAdministration.click();
@@ -228,7 +228,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
       const vorname: string = await generateVorname();
       const nachname: string = await generateNachname();
-      const schulstrukturknoten: string = testschule;
+      const schulstrukturknoten: string = testschuleName;
       const rolle: string = 'Lehrkraft';
       let userInfo: UserInfo;
 
@@ -292,7 +292,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
       const vorname: string = await generateVorname();
       const nachname: string = await generateNachname();
-      const schulstrukturknoten: string = testschule;
+      const schulstrukturknoten: string = testschuleName;
       const klasse: string = 'Playwright3a';
 
       await test.step(`Dialog Person anlegen öffnen`, async () => {
@@ -361,7 +361,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       const Organisation_Land: string = landSH;
       const Organisation_OeffentlicheSchule: string = oeffentlichLandSH;
       const Organisation_Ersatzschule: string = ersatzLandSH;
-      const Organisation_Schule: string = testschule;
+      const Organisation_Schule: string = testschuleName;
 
       const rolleLehr: string = 'Lehrkraft';
       const rolleLiV: string = 'LiV';
@@ -437,7 +437,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       const vorname: string = await generateVorname();
       const nachname: string = await generateNachname();
       const kopersnr: string = await generateKopersNr();
-      const schulstrukturknoten: string = testschule;
+      const schulstrukturknoten: string = testschuleName;
 
       await test.step(`Benutzer Lehrkraft anlegen`, async () => {
         await page.goto('/' + 'admin/personen/new');
@@ -493,10 +493,10 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
         await personManagementView.waitForData();
 
         // Fill the input with the name of the Schule and let the autocomplete find it
-        await personManagementView.comboboxMenuIcon_Schule_input.fill(testschule665);
+        await personManagementView.comboboxMenuIcon_Schule_input.fill(testschule665Name);
 
         // Click on the found Schule
-        await page.getByRole('option', { name: testschule665 }).click();
+        await page.getByRole('option', { name: testschule665Name }).click();
 
         // Close the dropdown
         await personManagementView.comboboxMenuIcon_Schule.click();
@@ -520,8 +520,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       const vorname: string = await generateVorname();
       const nachname: string = await generateNachname();
       const kopersnr: string = await generateKopersNr();
-      const schulstrukturknoten: string = testschule;
-      const dienststellenNr: string = '1111111';
+      const schulstrukturknoten: string = testschuleName;
 
       await test.step(`Dialog Person anlegen öffnen`, async () => {
         await page.goto('/' + 'admin/personen/new');
@@ -536,7 +535,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
           vorname,
           nachname,
           rolle,
-          dienststellenNr,
+          testschuleDstNr,
           schulstrukturknoten
         );
         usernames.push(await personCreationView.dataBenutzername.innerText());
@@ -594,8 +593,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       });
 
       // Testdaten
-      const schulstrukturknoten: string = testschule;
-      const dienststellenNr: string = '1111111';
+      const schulstrukturknoten: string = testschuleName;
       const vorname1: string = await generateVorname();
       const nachname1: string = await generateNachname();
       const klassenname: string = 'Playwright3a';
@@ -650,7 +648,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
         await expect(personCreationView.dataRolle).toHaveText(schuelerRolle);
         await expect(personCreationView.labelOrganisationsebene).toHaveText('Organisationsebene:');
         await expect(personCreationView.dataOrganisationsebene).toHaveText(
-          dienststellenNr + ' (' + schulstrukturknoten + ')'
+          testschuleDstNr + ' (' + schulstrukturknoten + ')'
         );
         await expect(personCreationView.labelKlasse).toHaveText('Klasse:');
         await expect(personCreationView.dataKlasse).toHaveText(klassenname);
@@ -692,7 +690,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
         await expect(personCreationView.dataRolle).toHaveText(rolle2);
         await expect(personCreationView.labelOrganisationsebene).toHaveText('Organisationsebene:');
         await expect(personCreationView.dataOrganisationsebene).toHaveText(
-          dienststellenNr + ' (' + schulstrukturknoten + ')'
+          testschuleDstNr + ' (' + schulstrukturknoten + ')'
         );
         await expect(personCreationView.buttonWeiterenBenutzerAnlegen).toBeVisible();
         await expect(personCreationView.buttonZurueckErgebnisliste).toBeVisible();
@@ -732,7 +730,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
         await expect(personCreationView.dataRolle).toHaveText(rolle3);
         await expect(personCreationView.labelOrganisationsebene).toHaveText('Organisationsebene:');
         await expect(personCreationView.dataOrganisationsebene).toHaveText(
-          dienststellenNr + ' (' + schulstrukturknoten + ')'
+          testschuleDstNr + ' (' + schulstrukturknoten + ')'
         );
         await expect(personCreationView.buttonWeiterenBenutzerAnlegen).toBeVisible();
         await expect(personCreationView.buttonZurueckErgebnisliste).toBeVisible();

--- a/tests/PersonBearbeiten.spec.ts
+++ b/tests/PersonBearbeiten.spec.ts
@@ -12,7 +12,7 @@ import { addSystemrechtToRolle } from '../base/api/testHelperRolle.page.ts';
 import { LONG, STAGE, BROWSER } from '../base/tags.ts';
 import { deletePersonenBySearchStrings, deleteRolleById } from '../base/testHelperDeleteTestdata.ts';
 import { typeLehrer, typeSchueler, typeSchuladmin } from '../base/rollentypen.ts';
-import { landSH, testschule, testschule665 } from '../base/organisation.ts';
+import { landSH, testschuleName, testschule665Name, testschuleDstNr } from '../base/organisation.ts';
 import { email, itslearning } from '../base/sp.ts';
 import {
   generateNachname,
@@ -20,10 +20,10 @@ import {
   generateRolleName,
   generateKopersNr,
 } from '../base/testHelperGenerateTestdataNames.ts';
-import { generateDate, generateDateToday, gotoTargetURL } from '../base/testHelperUtils.ts';
+import { generateCurrentDate, gotoTargetURL } from '../base/testHelperUtils.ts';
 import { lehrkraftOeffentlichRolle, lehrkraftInVertretungRolle } from '../base/rollen.ts';
 import FromAnywhere from '../pages/FromAnywhere';
-import { before } from 'node:test';
+import { befristungPflicht, kopersNrPflicht } from '../base/merkmale.ts';
 
 const PW: string | undefined = process.env.PW;
 const ADMIN: string | undefined = process.env.USER;
@@ -93,7 +93,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       const adminNachname: string = await generateNachname();
       const adminRolle: string = await generateRolleName();
       const adminRollenart: string = typeSchuladmin;
-      const adminOrganisation: string = testschule665;
+      const adminOrganisation: string = testschule665Name;
       const adminIdSPs: string[] = [await getSPId(page, 'Schulportal-Administration')];
       let userInfoAdmin: UserInfo;
 
@@ -101,7 +101,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       const lehrerNachname: string = await generateNachname();
       const lehrerRolle: string = await generateRolleName();
       const lehrerRollenart: string = typeLehrer;
-      const lehrerOrganisation: string = testschule665;
+      const lehrerOrganisation: string = testschule665Name;
 
       let userInfoLehrer: UserInfo;
       let lehrerBenutzername: string = '';
@@ -183,7 +183,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
     await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) und SP(email) über die api anlegen ${ADMIN}`, async () => {
       userInfoLehrer = await createRolleAndPersonWithUserContext(
         page,
-        testschule,
+        testschuleName,
         typeLehrer,
         await generateNachname(),
         await generateVorname(),
@@ -206,7 +206,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
     await test.step(`Ansicht für neuen Personenkontext öffnen`, async () => {
       await personDetailsView.button_editSchulzuordnung.click();
       await personDetailsView.button_addSchulzuordnung.click();
-      await personDetailsView.organisationenInput.searchByTitle(testschule, false);
+      await personDetailsView.organisationenInput.searchByTitle(testschuleName, false);
     });
 
     await test.step(`Befristung bei ${unbefristeteRolle} und ${befristeteRolle} überprüfen`, async () => {
@@ -222,12 +222,12 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
     { tag: [LONG, STAGE, BROWSER] },
     async ({ page }: PlaywrightTestArgs) => {
       let userInfoLehrer: UserInfo;
-      const sperrDatumAbHeute = await generateDateToday();
+      const sperrDatumAbHeute = await generateCurrentDate({ days: 0, months: 0, formatDMY: true });
 
       await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) und SP(email) über die api anlegen ${ADMIN}`, async () => {
         userInfoLehrer = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           typeLehrer,
           await generateNachname(),
           await generateVorname(),
@@ -257,13 +257,13 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
   test('Einen Benutzer über das FE befristet sperren', { tag: [LONG, STAGE] }, async ({ page }: PlaywrightTestArgs) => {
     let userInfoLehrer: UserInfo;
-    const sperrDatumAbHeute = await generateDateToday();
-    const sperrDatumBis = await generateDate(5, 2);
+    const sperrDatumAbHeute = await generateCurrentDate({ days: 0, months: 0, formatDMY: true });
+    const sperrDatumBis = await generateCurrentDate({ days: 5, months: 2, formatDMY: true });
 
     await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) und SP(email) über die api anlegen ${ADMIN}`, async () => {
       userInfoLehrer = await createRolleAndPersonWithUserContext(
         page,
-        testschule,
+        testschuleName,
         typeLehrer,
         await generateNachname(),
         await generateVorname(),
@@ -300,7 +300,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       await test.step(`Testdaten: Schüler mit einer Rolle(LERN) über die api anlegen ${ADMIN}`, async () => {
         userInfoLehrer = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           typeSchueler,
           await generateNachname(),
           await generateVorname(),
@@ -345,7 +345,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) über die api anlegen ${ADMIN}`, async () => {
         userInfoLehrer = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           typeLehrer,
           await generateNachname(),
           await generateVorname(),
@@ -378,7 +378,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       const addminVorname: string = await generateVorname();
       const adminNachname: string = await generateNachname();
       const adminRollenart: string = typeSchuladmin;
-      const adminOrganisation: string = testschule665;
+      const adminOrganisation: string = testschule665Name;
       let userInfoAdmin: UserInfo;
 
       await test.step(`Testdaten: Schuladmin mit einer Rolle(LEIT) über die api anlegen ${ADMIN}`, async () => {
@@ -469,7 +469,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
     { tag: [LONG, STAGE, BROWSER] },
     async ({ page }: PlaywrightTestArgs) => {
       const adminRollenart: string = typeSchuladmin;
-      const adminOrganisation: string = testschule665;
+      const adminOrganisation: string = testschule665Name;
       let userInfoAdmin: UserInfo;
 
       await test.step(`Testdaten: Schuladmin mit einer Rolle(LEIT) über die api anlegen ${ADMIN}`, async () => {
@@ -512,11 +512,10 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
     { tag: [LONG, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
       let userInfoLehrer: UserInfo;
-
       await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) über die api anlegen ${ADMIN}`, async () => {
         userInfoLehrer = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           typeLehrer,
           await generateNachname(),
           await generateVorname(),
@@ -556,7 +555,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) über die api anlegen`, async () => {
         userInfoLehrer = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           typeLehrer,
           await generateNachname(),
           await generateVorname(),
@@ -582,18 +581,20 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
     }
   );
 
-  test.only(
-    'Befristung einer Schulzoordnung bearbeiten',
+  test(
+    'Befristung einer Schulzuordnung von einem Lehrer durch einen Landesadmin bearbeiten',
     { tag: [LONG, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
       let userInfoLehrer: UserInfo;
-      const befristungLehrerRolle = await generateDate(3, 5, false);
-      const nameRolle = await generateRolleName();
+      const timeLimitTeacherRolle: string = await generateCurrentDate({ days: 3, months: 5, formatDMY: true });
+      let timeLimitTeacherRolleNew: string;
+      const nameRolle: string = await generateRolleName();
+      let colorTextEntireNameSchulzuordnung: string = '';
 
-      await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) über die api anlegen`, async () => {
+      await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) und einer Schulzuordnung über die api anlegen`, async () => {
         userInfoLehrer = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           typeLehrer,
           await generateNachname(),
           await generateVorname(),
@@ -608,46 +609,164 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
           userInfoLehrer.personId,
           userInfoLehrer.organisationId,
           userInfoLehrer.rolleId,
-          await generateDate(3, 5, true)
+          await generateCurrentDate({ days: 3, months: 5, formatDMY: false })
         );
       });
 
-      const personManagementView: PersonManagementViewPage = new PersonManagementViewPage(page);
-
       const personDetailsView: PersonDetailsViewPage = await test.step(`Gesamtübersicht öffnen`, async () => {
+        const personManagementView: PersonManagementViewPage = new PersonManagementViewPage(page);
         await gotoTargetURL(page, 'admin/personen');
         await personManagementView.waitErgebnislisteIsLoaded();
         await personManagementView.searchBySuchfeld(userInfoLehrer.username);
         return await personManagementView.openGesamtuebersichtPerson(page, userInfoLehrer.username);
       });
 
-      await test.step(`Befristung ändern`, async () => {
+      await test.step(`Schulzuordnung im Bearbeitungsmodus öffen`, async () => {
         await personDetailsView.button_editSchulzuordnung.click();
-        // open the showed school assignment
         await page
           .getByTestId('person-details-card')
           .getByText(
-            '1111111 ' + '(' + testschule + '): ' + nameRolle + ' (befristet bis ' + befristungLehrerRolle + ')'
+            testschuleDstNr +
+              ' (' +
+              testschuleName +
+              '): ' +
+              nameRolle +
+              ' (befristet bis ' +
+              timeLimitTeacherRolle +
+              ')'
           )
           .click();
+      });
 
+      await test.step(`Befristung im Bearbeitungsmodus öffnen`, async () => {
         await personDetailsView.buttonBefristungAendern.click();
-        await expect(personDetailsView.radioButtonBefristungSchuljahresende).toBeEnabled();
-        await expect(personDetailsView.radioButtonUnbefristet).toBeEnabled();
-        // enter invalid date
-        await personDetailsView.inputBefristung.fill(await generateDate(0, 0, false)); // today
-        await personDetailsView.errorTextInputBefristung.isEnabled();
-        await personDetailsView.inputBefristung.fill(await generateDate(0, -3, false)); // past
-        await personDetailsView.errorTextInputBefristung.isEnabled();
-        // enter valid date
-        await personDetailsView.inputBefristung.fill(await generateDate(22, 6, false)); // future
-        await personDetailsView.errorTextInputBefristung.isDisabled();
-        await personDetailsView.inputBefristung.fill(await generateDate(0, 8, false)); // future
-        await personDetailsView.errorTextInputBefristung.isDisabled();
-        // save new date
-        await page.getByTestId('change-befristung-submit-button').click();
+        await expect(personDetailsView.radioButtonBefristungSchuljahresende).toBeVisible();
+        await expect(personDetailsView.radioButtonUnbefristet).toBeVisible();
+      });
 
-        await page.pause();
+      await test.step(`Ungültige und gültige Befristungen eingeben`, async () => {
+        // enter invalid date
+        await personDetailsView.inputBefristung.fill(
+          await generateCurrentDate({ days: 0, months: 0, formatDMY: true })
+        );
+        await personDetailsView.errorTextInputBefristung.isEnabled();
+
+        await personDetailsView.inputBefristung.fill(
+          await generateCurrentDate({ days: 0, months: -3, formatDMY: true })
+        );
+        await personDetailsView.errorTextInputBefristung.isEnabled();
+
+        // enter valid date
+        await personDetailsView.inputBefristung.fill(
+          await generateCurrentDate({ days: 22, months: 6, formatDMY: true })
+        );
+        await personDetailsView.errorTextInputBefristung.isDisabled();
+
+        timeLimitTeacherRolleNew = await generateCurrentDate({ days: 0, months: 8, formatDMY: true });
+        await personDetailsView.inputBefristung.fill(timeLimitTeacherRolleNew);
+        await personDetailsView.errorTextInputBefristung.isDisabled();
+      });
+
+      await test.step(`Gültige Befristung speichern`, async () => {
+        await personDetailsView.buttonBefristungAendernSubmit.click();
+        await expect(
+          page.getByText(
+            'Möchten Sie die Befristung wirklich von ' +
+              timeLimitTeacherRolle +
+              ' in ' +
+              timeLimitTeacherRolleNew +
+              ' ändern?'
+          )
+        ).toBeVisible();
+        await personDetailsView.buttonBefristungAendernConfirm.click();
+      });
+
+      await test.step(`In der Änderungsübersicht die Befristung der Rolle überprüfen und das Speichern final bestätigen`, async () => {
+        await expect(
+          page.getByRole('heading', { name: 'Bitte prüfen und abschließend speichern, um die Aktion auszuführen:' })
+        ).toBeVisible();
+
+        colorTextEntireNameSchulzuordnung = 'rgb(244, 67, 54)';
+        await personDetailsView.validateEntireNameSchulzuordnung(
+          testschuleDstNr,
+          testschuleName,
+          nameRolle,
+          colorTextEntireNameSchulzuordnung,
+          timeLimitTeacherRolle
+        );
+
+        colorTextEntireNameSchulzuordnung = 'rgb(76, 175, 80)';
+        await personDetailsView.validateEntireNameSchulzuordnung(
+          testschuleDstNr,
+          testschuleName,
+          nameRolle,
+          colorTextEntireNameSchulzuordnung,
+          timeLimitTeacherRolleNew
+        );
+        await personDetailsView.buttonBefristungAendernSave.click();
+        await personDetailsView.buttonBefristungAendernSuccessClose.click();
+        await personDetailsView.teardownAPI({ lastEndpoint: 'organisationen/parents-by-ids' });
+      });
+
+      await test.step(`In der Gesamtübersicht überprüfen, dass die Schulzuordnung mit dem korrekten Datum angezeigt wird`, async () => {
+        colorTextEntireNameSchulzuordnung = 'rgb(0, 30, 73)';
+        await personDetailsView.validateEntireNameSchulzuordnung(
+          testschuleDstNr,
+          testschuleName,
+          nameRolle,
+          colorTextEntireNameSchulzuordnung,
+          timeLimitTeacherRolleNew
+        );
+      });
+    }
+  );
+
+  test(
+    `Prüfen, dass eine Person mit einer befristeten Rolle wie z.B. LiV, nicht die Option 'Unbefristet' bekommen kann wenn man eine Befristung bearbeitet`,
+    { tag: [LONG, STAGE] },
+    async ({ page }: PlaywrightTestArgs) => {
+      let userInfoLehrer: UserInfo;
+      const nameRolle: string = await generateRolleName();
+
+      await test.step(`Testdaten: Lehrer mit einer Rolle(LiV) mit den Merkmalen 'BefristungsPflicht', 'KopersPflicht' und einer Schulzuordnung über die api anlegen`, async () => {
+        userInfoLehrer = await createRolleAndPersonWithUserContext(
+          page,
+          testschuleName,
+          typeLehrer,
+          await generateNachname(),
+          await generateVorname(),
+          [await getSPId(page, email)],
+          nameRolle,
+          await generateKopersNr(),
+          undefined,
+          [befristungPflicht, kopersNrPflicht]
+        );
+        usernames.push(userInfoLehrer.username);
+        rolleIds.push(userInfoLehrer.rolleId);
+      });
+
+      const personDetailsView: PersonDetailsViewPage = await test.step(`Gesamtübersicht öffnen`, async () => {
+        const personManagementView: PersonManagementViewPage = new PersonManagementViewPage(page);
+        await gotoTargetURL(page, 'admin/personen');
+        await personManagementView.waitErgebnislisteIsLoaded();
+        await personManagementView.searchBySuchfeld(userInfoLehrer.username);
+        return await personManagementView.openGesamtuebersichtPerson(page, userInfoLehrer.username);
+      });
+
+      await test.step(`Schulzuordnung im Bearbeitungsmodus öffen`, async () => {
+        await personDetailsView.button_editSchulzuordnung.click();
+        await page
+          .getByTestId('person-details-card')
+          .getByText(testschuleDstNr + ' (' + testschuleName + '): ' + nameRolle + ' (befristet bis ')
+          .click();
+        await personDetailsView.teardownAPI({ lastEndpoint: 'personenkontext-workflow/**' });
+      });
+
+      await test.step(`Befristung im Bearbeitungsmodus öffnen`, async () => {
+        await personDetailsView.buttonBefristungAendern.click();
+        await expect(personDetailsView.radioButtonBefristungSchuljahresende).toBeVisible();
+        await expect(personDetailsView.radioButtonUnbefristet).toBeVisible();
+        await expect(personDetailsView.radioButtonUnbefristetDisabled).toBeDisabled();
       });
     }
   );

--- a/tests/PersonBearbeiten.spec.ts
+++ b/tests/PersonBearbeiten.spec.ts
@@ -620,7 +620,6 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
       const personDetailsView: PersonDetailsViewPage = await test.step(`Gesamtübersicht öffnen`, async () => {
         await gotoTargetURL(page, 'admin/personen');
-        await personManagementView.waitErgebnislisteIsLoaded();
         await personManagementView.searchBySuchfeld(userInfoLehrer.username);
         return await personManagementView.openGesamtuebersichtPerson(page, userInfoLehrer.username);
       });
@@ -670,14 +669,12 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       const personDetailsView: PersonDetailsViewPage = await test.step(`Gesamtübersicht öffnen`, async () => {
         const personManagementView: PersonManagementViewPage = new PersonManagementViewPage(page);
         await gotoTargetURL(page, 'admin/personen');
-        //await personManagementView.waitErgebnislisteIsLoaded();
         await personManagementView.searchBySuchfeld(userInfoLehrer.username);
         return await personManagementView.openGesamtuebersichtPerson(page, userInfoLehrer.username);
       });
 
       await test.step(`Schulzuordnung im Bearbeitungsmodus öffen`, async () => {
         await personDetailsView.button_editSchulzuordnung.click();
-        console.log(timeLimitTeacherRolle);
         await page
           .getByTestId('person-details-card')
           .getByText(

--- a/tests/PersonBearbeiten.spec.ts
+++ b/tests/PersonBearbeiten.spec.ts
@@ -581,7 +581,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
     }
   );
 
-  test(
+  test.only(
     'Befristung einer Schulzuordnung von einem Lehrer durch einen Landesadmin bearbeiten',
     { tag: [LONG, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
@@ -612,17 +612,18 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
           await generateCurrentDate({ days: 3, months: 5, formatDMY: false })
         );
       });
-
+      
       const personDetailsView: PersonDetailsViewPage = await test.step(`Gesamtübersicht öffnen`, async () => {
         const personManagementView: PersonManagementViewPage = new PersonManagementViewPage(page);
         await gotoTargetURL(page, 'admin/personen');
-        await personManagementView.waitErgebnislisteIsLoaded();
+        //await personManagementView.waitErgebnislisteIsLoaded();
         await personManagementView.searchBySuchfeld(userInfoLehrer.username);
         return await personManagementView.openGesamtuebersichtPerson(page, userInfoLehrer.username);
       });
 
       await test.step(`Schulzuordnung im Bearbeitungsmodus öffen`, async () => {
         await personDetailsView.button_editSchulzuordnung.click();
+        console.log(timeLimitTeacherRolle);
         await page
           .getByTestId('person-details-card')
           .getByText(
@@ -649,22 +650,22 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
         await personDetailsView.inputBefristung.fill(
           await generateCurrentDate({ days: 0, months: 0, formatDMY: true })
         );
-        await personDetailsView.errorTextInputBefristung.isEnabled();
+        await personDetailsView.errorTextInputBefristung.isVisible();
 
         await personDetailsView.inputBefristung.fill(
           await generateCurrentDate({ days: 0, months: -3, formatDMY: true })
         );
-        await personDetailsView.errorTextInputBefristung.isEnabled();
+        await personDetailsView.errorTextInputBefristung.isVisible();
 
         // enter valid date
         await personDetailsView.inputBefristung.fill(
           await generateCurrentDate({ days: 22, months: 6, formatDMY: true })
         );
-        await personDetailsView.errorTextInputBefristung.isDisabled();
+        await personDetailsView.errorTextInputBefristung.isHidden();
 
         timeLimitTeacherRolleNew = await generateCurrentDate({ days: 0, months: 8, formatDMY: true });
         await personDetailsView.inputBefristung.fill(timeLimitTeacherRolleNew);
-        await personDetailsView.errorTextInputBefristung.isDisabled();
+        await personDetailsView.errorTextInputBefristung.isHidden();
       });
 
       await test.step(`Gültige Befristung speichern`, async () => {
@@ -705,7 +706,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
         );
         await personDetailsView.buttonBefristungAendernSave.click();
         await personDetailsView.buttonBefristungAendernSuccessClose.click();
-        await personDetailsView.teardownAPI({ lastEndpoint: 'organisationen/parents-by-ids' });
+        await personDetailsView.waitForAPIResponse({ lastEndpoint: 'organisationen/parents-by-ids' });
       });
 
       await test.step(`In der Gesamtübersicht überprüfen, dass die Schulzuordnung mit dem korrekten Datum angezeigt wird`, async () => {
@@ -748,7 +749,6 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       const personDetailsView: PersonDetailsViewPage = await test.step(`Gesamtübersicht öffnen`, async () => {
         const personManagementView: PersonManagementViewPage = new PersonManagementViewPage(page);
         await gotoTargetURL(page, 'admin/personen');
-        await personManagementView.waitErgebnislisteIsLoaded();
         await personManagementView.searchBySuchfeld(userInfoLehrer.username);
         return await personManagementView.openGesamtuebersichtPerson(page, userInfoLehrer.username);
       });
@@ -759,7 +759,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
           .getByTestId('person-details-card')
           .getByText(testschuleDstNr + ' (' + testschuleName + '): ' + nameRolle + ' (befristet bis ')
           .click();
-        await personDetailsView.teardownAPI({ lastEndpoint: 'personenkontext-workflow/**' });
+        await personDetailsView.waitForAPIResponse({ lastEndpoint: 'personenkontext-workflow/**' });
       });
 
       await test.step(`Befristung im Bearbeitungsmodus öffnen`, async () => {

--- a/tests/PersonBearbeiten.spec.ts
+++ b/tests/PersonBearbeiten.spec.ts
@@ -581,7 +581,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
     }
   );
 
-  test.only(
+  test(
     'Befristung einer Schulzuordnung von einem Lehrer durch einen Landesadmin bearbeiten',
     { tag: [LONG, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {

--- a/tests/Profile.spec.ts
+++ b/tests/Profile.spec.ts
@@ -4,7 +4,7 @@ import { getOrganisationId } from '../base/api/testHelperOrganisation.page';
 import { addSecondOrganisationToPerson, createRolleAndPersonWithUserContext } from '../base/api/testHelperPerson.page';
 import { addSystemrechtToRolle } from '../base/api/testHelperRolle.page';
 import { getSPId } from '../base/api/testHelperServiceprovider.page';
-import { landSH, testschule, testschule665 } from '../base/organisation.ts';
+import { landSH, testschuleName, testschule665Name } from '../base/organisation.ts';
 import { typeLandesadmin, typeLehrer, typeSchueler, typeSchuladmin } from '../base/rollentypen.ts';
 import { email, itslearning, schulportaladmin } from '../base/sp.ts';
 import { BROWSER, LONG, SHORT, STAGE } from '../base/tags';
@@ -30,6 +30,7 @@ import {
   schultraegerVerwalten,
   personenAnlegen,
 } from '../base/berechtigungen.ts';
+import { testschuleDstNr } from '../base/organisation.ts';
 
 const PW: string | undefined = process.env.PW;
 const ADMIN: string | undefined = process.env.USER;
@@ -171,8 +172,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
 
       const vorname: string = await generateVorname();
       const nachname: string = await generateNachname();
-      const organisation: string = testschule;
-      const dienststellenNr: string = '1111111';
+      const organisation: string = testschuleName;
       const rollenname: string = await generateRolleName();
       const rollenart: string = typeLehrer;
 
@@ -213,7 +213,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
         await expect(profileView.labelRolle1).toHaveText('Rolle:');
         await expect(profileView.dataRolle1).toHaveText(rollenname);
         await expect(profileView.labelDienststellennummer1).toHaveText('DStNr.:');
-        await expect(profileView.dataDienststellennummer1).toHaveText(dienststellenNr);
+        await expect(profileView.dataDienststellennummer1).toHaveText(testschuleDstNr);
         // Passwort
         await expect(profileView.cardHeadlinePasswort).toHaveText('Passwort');
         await expect(profileView.buttonStartPWChangeDialog).toBeEnabled();
@@ -234,8 +234,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
 
       const vorname: string = await generateVorname();
       const nachname: string = await generateNachname();
-      const organisation: string = testschule;
-      const dienststellenNr: string = '1111111';
+      const organisation: string = testschuleName;
       const rollenname: string = await generateRolleName();
       const rollenart: string = typeSchueler;
 
@@ -276,7 +275,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
         await expect(profileView.labelRolle1).toHaveText('Rolle:');
         await expect(profileView.dataRolle1).toHaveText(rollenname);
         await expect(profileView.labelDienststellennummer1).toHaveText('DStNr.:');
-        await expect(profileView.dataDienststellennummer1).toHaveText(dienststellenNr);
+        await expect(profileView.dataDienststellennummer1).toHaveText(testschuleDstNr);
         // Passwort
         await expect(profileView.cardHeadlinePasswort).toHaveText('Passwort');
         await expect(profileView.buttonStartPWChangeDialog).toBeEnabled();
@@ -297,8 +296,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
 
       const vorname: string = await generateVorname();
       const nachname: string = await generateNachname();
-      const organisation: string = testschule;
-      const dienststellenNr: string = '1111111';
+      const organisation: string = testschuleName;
       const rollenname: string = await generateRolleName();
       const rollenart: string = typeSchuladmin;
 
@@ -339,7 +337,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
         await expect(profileView.labelRolle1).toHaveText('Rolle:');
         await expect(profileView.dataRolle1).toHaveText(rollenname);
         await expect(profileView.labelDienststellennummer1).toHaveText('DStNr.:');
-        await expect(profileView.dataDienststellennummer1).toHaveText(dienststellenNr);
+        await expect(profileView.dataDienststellennummer1).toHaveText(testschuleDstNr);
         // Passwort
         await expect(profileView.cardHeadlinePasswort).toHaveText('Passwort');
         await expect(profileView.buttonStartPWChangeDialog).toBeEnabled();
@@ -360,9 +358,8 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
 
       const vorname: string = await generateVorname();
       const nachname: string = await generateNachname();
-      const organisation1: string = testschule;
-      const organisation2: string = testschule665;
-      const dienststellenNr1: string = '1111111';
+      const organisation1: string = testschuleName;
+      const organisation2: string = testschule665Name;
       const dienststellenNr2: string = '1111165';
       const rollenname: string = await generateRolleName();
       const rollenart: string = typeLehrer;
@@ -413,7 +410,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
           await expect(profileView.labelRolle1).toHaveText('Rolle:');
           await expect(profileView.dataRolle1).toHaveText(rollenname);
           await expect(profileView.labelDienststellennummer1).toHaveText('DStNr.:');
-          await expect(profileView.dataDienststellennummer1).toHaveText(dienststellenNr1);
+          await expect(profileView.dataDienststellennummer1).toHaveText(testschuleDstNr);
 
           // Schulzuordnung 2
           await expect(profileView.cardHeadline_Schulzuordnung2).toHaveText('Schulzuordnung 2');
@@ -437,7 +434,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
           await expect(profileView.labelRolle2).toHaveText('Rolle:');
           await expect(profileView.dataRolle2).toHaveText(rollenname);
           await expect(profileView.labelDienststellennummer2).toHaveText('DStNr.:');
-          await expect(profileView.dataDienststellennummer2).toHaveText(dienststellenNr1);
+          await expect(profileView.dataDienststellennummer2).toHaveText(testschuleDstNr);
 
           // Schulzuordnung 2
           await expect(profileView.cardHeadline_Schulzuordnung1).toHaveText('Schulzuordnung 1');
@@ -467,7 +464,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
       const header: HeaderPage = new HeaderPage(page);
       const login: LoginPage = new LoginPage(page);
 
-      const organisation: string = testschule;
+      const organisation: string = testschuleName;
       const rollenart: string = typeSchueler;
 
       await test.step(`Lehrer via api anlegen und mit diesem anmelden`, async () => {
@@ -524,7 +521,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
       const header: HeaderPage = new HeaderPage(page);
       const login: LoginPage = new LoginPage(page);
 
-      const organisation: string = testschule;
+      const organisation: string = testschuleName;
       const rollenart: string = typeLehrer;
 
       await test.step(`Lehrer via api anlegen und mit diesem anmelden`, async () => {
@@ -627,7 +624,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
       await test.step(`Lehrer und Schüler via api anlegen`, async () => {
         userInfoLehrer = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           typeLehrer,
           await generateNachname(),
           await generateVorname(),
@@ -640,7 +637,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
 
         userInfoSchueler = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           typeSchueler,
           await generateNachname(),
           await generateVorname(),
@@ -704,7 +701,7 @@ test.describe(`Testfälle für das eigene Profil anzeigen: Umgebung: ${process.e
       await test.step(`Testdaten: Lehrer mit einer Rolle(LEHR) über die api anlegen und mit diesem anmelden`, async () => {
         userInfoLehrer = await createRolleAndPersonWithUserContext(
           page,
-          testschule,
+          testschuleName,
           typeLehrer,
           await generateNachname(),
           await generateVorname(),

--- a/tests/Rolle.spec.ts
+++ b/tests/Rolle.spec.ts
@@ -57,7 +57,7 @@ test.describe(`Testfälle für die Administration von Rollen: Umgebung: ${proces
     '2 Rollen nacheinander anlegen mit Rollenarten LERN und LEHR als Landesadmin',
     { tag: [LONG, SHORT, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
-      const rollenname1:  string = await generateRolleName();
+      const rollenname1: string = await generateRolleName();
       const rollenname2: string = await generateRolleName();
       const schulstrukturknoten1: string = landSH;
       const schulstrukturknoten2: string = ersatzLandSH;
@@ -69,7 +69,9 @@ test.describe(`Testfälle für die Administration von Rollen: Umgebung: ${proces
       const angebotB2: string = kalender;
 
       const rolleCreationView: RolleCreationViewPage = await test.step(`Dialog Rolle anlegen öffnen`, async () => {
-        const rolleCreationView: RolleCreationViewPage = await startseite.goToAdministration().then((menu) => menu.rolleAnlegen());
+        const rolleCreationView: RolleCreationViewPage = await startseite
+          .goToAdministration()
+          .then((menu) => menu.rolleAnlegen());
         await expect(rolleCreationView.textH2RolleAnlegen).toHaveText('Neue Rolle hinzufügen');
         return rolleCreationView;
       });
@@ -118,7 +120,7 @@ test.describe(`Testfälle für die Administration von Rollen: Umgebung: ${proces
     { tag: [LONG, SHORT, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
       await test.step(`Rollenverwaltung öffnen und alle Elemente in der Ergebnisliste auf Existenz prüfen`, async () => {
-        const menu: MenuPage = await startseite.goToAdministration();   
+        const menu: MenuPage = await startseite.goToAdministration();
         const rolleManagement: RolleManagementViewPage = await menu.alleRollenAnzeigen();
         await expect(rolleManagement.textH1Administrationsbereich).toBeVisible();
         await expect(rolleManagement.textH2Rollenverwaltung).toBeVisible();
@@ -126,9 +128,10 @@ test.describe(`Testfälle für die Administration von Rollen: Umgebung: ${proces
         await expect(rolleManagement.tableHeaderRollenart).toBeVisible();
         await expect(rolleManagement.tableHeaderMerkmale).toBeVisible();
         await expect(rolleManagement.tableHeaderAdministrationsebene).toBeVisible();
-        await expect(page.getByRole('cell', { name: 'itslearning-Schüler' })).toBeVisible(); 
-    });
-  });
+        await expect(page.getByRole('cell', { name: 'itslearning-Schüler' })).toBeVisible();
+      });
+    }
+  );
 
   test(
     'Eine Rolle anlegen und die Bestätigungsseite vollständig prüfen als Landesadmin',
@@ -208,7 +211,7 @@ test.describe(`Testfälle für die Administration von Rollen: Umgebung: ${proces
       await expect(rolleDetailsView.rolleForm.rollenname.messages).toBeVisible();
       await expect(rolleDetailsView.rolleForm.rollenname.messages).toHaveText('Der Rollenname muss ausgewählt werden.');
       await rolleDetailsView.rolleForm.rollenname.inputElement.fill('a');
-      await expect(rolleDetailsView.rolleForm.rollenname.messages).toHaveText("");
+      await expect(rolleDetailsView.rolleForm.rollenname.messages).toHaveText('');
     });
 
     await test.step('zu lange Eingaben', async () => {
@@ -224,9 +227,11 @@ test.describe(`Testfälle für die Administration von Rollen: Umgebung: ${proces
       for (let index = 0; index < illegalCharacters.length; index++) {
         await rolleDetailsView.rolleForm.rollenname.inputElement.fill(illegalCharacters[index]);
         await expect(rolleDetailsView.rolleForm.rollenname.messages.getByText('ungültig')).toBeVisible();
-        await expect(rolleDetailsView.rolleForm.rollenname.messages.getByText('ungültig')).toHaveText('Der Rollenname darf keine ungültigen Zeichen beinhalten.');
+        await expect(rolleDetailsView.rolleForm.rollenname.messages.getByText('ungültig')).toHaveText(
+          'Der Rollenname darf keine ungültigen Zeichen beinhalten.'
+        );
       }
-    })
+    });
   });
 
   test('Versuch eine zugewiesene Rolle zu löschen', { tag: [LONG] }, async () => {
@@ -298,12 +303,12 @@ test.describe('Testet die Anlage einer neuen Rolle', () => {
     }
   );
 
-  test('Falsche Eingaben überprüfen', { tag: [LONG] }, async () => {
+  test('Falsche Eingaben überprüfen', { tag: [LONG] }, async ({}: PlaywrightTestArgs) => {
     const rolleNames: string = 'a'.repeat(201);
     const rolleCreationView: RolleCreationViewPage = await test.step('Rolle anlegen aufrufen', async () => {
       return await startseite.goToAdministration().then((menu) => menu.rolleAnlegen());
     });
-    
+
     await test.step('leere Pflichtfelder', async () => {
       await expect(rolleCreationView.rolleForm.adminstrationsebene.messages).toBeHidden();
       await expect(rolleCreationView.rolleForm.rollenart.messages).toBeHidden();
@@ -318,16 +323,16 @@ test.describe('Testet die Anlage einer neuen Rolle', () => {
       await expect(rolleCreationView.rolleForm.rollenart.messages).toHaveText('Die Rollenart muss ausgewählt werden.');
 
       await rolleCreationView.rolleForm.adminstrationsebene.inputElement.selectByPosition([0]);
-      await expect(rolleCreationView.rolleForm.adminstrationsebene.messages).toHaveText("");
+      await expect(rolleCreationView.rolleForm.adminstrationsebene.messages).toHaveText('');
       await rolleCreationView.rolleForm.rollenart.inputElement.selectByPosition([0]);
-      await expect(rolleCreationView.rolleForm.rollenart.messages).toHaveText("");
+      await expect(rolleCreationView.rolleForm.rollenart.messages).toHaveText('');
 
       await expect(rolleCreationView.rolleForm.rollenname.messages).toBeVisible();
       await expect(rolleCreationView.rolleForm.rollenname.messages).toHaveText(
         'Der Rollenname muss ausgewählt werden.'
       );
       await rolleCreationView.enterRollenname('a');
-      await expect(rolleCreationView.rolleForm.rollenname.messages).toHaveText("");
+      await expect(rolleCreationView.rolleForm.rollenname.messages).toHaveText('');
     });
 
     await test.step('zu lange Eingaben', async () => {
@@ -343,7 +348,9 @@ test.describe('Testet die Anlage einer neuen Rolle', () => {
       for (let index = 0; index < illegalCharacters.length; index++) {
         await rolleCreationView.enterRollenname(illegalCharacters[index]);
         await expect(rolleCreationView.rolleForm.rollenname.messages.getByText('ungültig')).toBeVisible();
-        await expect(rolleCreationView.rolleForm.rollenname.messages.getByText('ungültig')).toHaveText('Der Rollenname darf keine ungültigen Zeichen beinhalten.');
+        await expect(rolleCreationView.rolleForm.rollenname.messages.getByText('ungültig')).toHaveText(
+          'Der Rollenname darf keine ungültigen Zeichen beinhalten.'
+        );
       }
     });
   });

--- a/tests/Rolle.spec.ts
+++ b/tests/Rolle.spec.ts
@@ -63,7 +63,6 @@ test.describe(`Testfälle für die Administration von Rollen: Umgebung: ${proces
     { tag: [LONG, SHORT, STAGE] },
     async ({ page }: PlaywrightTestArgs) => {
       const rollenname1: string = await generateRolleName();
-      const rollenname1: string = await generateRolleName();
       const rollenname2: string = await generateRolleName();
       const schulstrukturknoten1: string = landSH;
       const schulstrukturknoten2: string = ersatzLandSH;

--- a/tests/SchulportalAdministration.spec.ts
+++ b/tests/SchulportalAdministration.spec.ts
@@ -10,7 +10,7 @@ import { UserInfo } from '../base/api/testHelper.page';
 import { LONG, SHORT, STAGE } from '../base/tags';
 import { deletePersonById, deleteRolleById } from '../base/testHelperDeleteTestdata';
 import { generateNachname, generateRolleName, generateVorname } from '../base/testHelperGenerateTestdataNames';
-import { testschule } from '../base/organisation';
+import { testschuleName } from '../base/organisation';
 import FromAnywhere from '../pages/FromAnywhere';
 import { email, itslearning, schulportaladmin } from '../base/sp';
 
@@ -80,7 +80,7 @@ test.describe(`Testfälle für Schulportal Administration": Umgebung: ${process.
       const idSPs: string[] = [await getSPId(page, 'E-Mail')];
       const userInfo: UserInfo = await createRolleAndPersonWithUserContext(
         page,
-        testschule,
+        testschuleName,
         'LEHR',
         await generateNachname(),
         await generateVorname(),
@@ -117,7 +117,7 @@ test.describe(`Testfälle für Schulportal Administration": Umgebung: ${process.
       const idSPs: string[] = [await getSPId(page, 'itslearning')];
       const userInfo: UserInfo = await createRolleAndPersonWithUserContext(
         page,
-        testschule,
+        testschuleName,
         'LERN',
         await generateNachname(),
         await generateVorname(),
@@ -154,7 +154,7 @@ test.describe(`Testfälle für Schulportal Administration": Umgebung: ${process.
       const idSPs: string[] = [await getSPId(page, 'Schulportal-Administration')];
       const userInfo: UserInfo = await createRolleAndPersonWithUserContext(
         page,
-        testschule,
+        testschuleName,
         'LEIT',
         await generateNachname(),
         await generateVorname(),

--- a/tests/TwoFactorAuthentication.spec.ts
+++ b/tests/TwoFactorAuthentication.spec.ts
@@ -4,7 +4,7 @@ import { createRolleAndPersonWithUserContext } from '../base/api/testHelperPerso
 import { getSPId } from '../base/api/testHelperServiceprovider.page';
 import { LONG, STAGE, BROWSER } from '../base/tags';
 import { generateNachname, generateVorname, generateRolleName } from '../base/testHelperGenerateTestdataNames';
-import { testschule } from '../base/organisation';
+import { testschuleName } from '../base/organisation';
 import { typeLehrer } from '../base/rollentypen';
 import { email } from '../base/sp';
 import { gotoTargetURL } from '../base/testHelperUtils';
@@ -58,7 +58,7 @@ test.describe(`Testfälle für TwoFactorAuthentication": Umgebung: ${process.env
     await test.step(`Testdaten erstellen`, async () => {
       userInfoLehrer = await createRolleAndPersonWithUserContext(
         page,
-        testschule,
+        testschuleName,
         typeLehrer,
         await generateNachname(),
         await generateVorname(),

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -10,7 +10,7 @@ import { UserInfo } from "../base/api/testHelper.page.ts";
 import { deletePersonenBySearchStrings, deleteRolleById } from "../base/testHelperDeleteTestdata.ts";
 import { getOrganisationId } from "../base/api/testHelperOrganisation.page.ts";
 import { generateRolleName, generateNachname, generateVorname } from '../base/testHelperGenerateTestdataNames.ts';
-import { testschule } from '../base/organisation.ts';
+import { testschuleName } from '../base/organisation.ts';
 
 const PW: string | undefined = process.env.PW;
 const ADMIN: string | undefined = process.env.USER;
@@ -97,7 +97,7 @@ test.describe(`Testfälle für die Authentifizierung: Umgebung: ${process.env.EN
     const lehrerNachname: string =await generateNachname();
     const lehrerRolle:string = await generateRolleName();
     const lehrerRollenart: string = 'LEHR';
-    const lehrerOrganisation: string = testschule;
+    const lehrerOrganisation: string = testschuleName;
     let userInfoLehrer: UserInfo;
     let organisationIDLandSh: string = '';
  


### PR DESCRIPTION
https://ticketsystem.dbildungscloud.de/browse/SPSH-1911

### 2 Neue Testfälle:

- Befristung einer Schulzuordnung von einem Lehrer durch einen Landesadmin bearbeiten

- Prüfen, dass eine Person mit einer befristeten Rolle wie z.B. LiV, nicht die Option 'Unbefristet' bekommen kann wenn man eine Befristung bearbeitet
### Anzahl workers von 2 auf 4 erhöht