### PR TITLE
SPSH-2082 add waitForAPIResponse after clear combobox organisation

### DIFF
--- a/tests/Person.spec.ts
+++ b/tests/Person.spec.ts
@@ -414,7 +414,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
       });
 
       await test.step(`Organisation 'Land Schleswig-Holstein' auswählen und Dropdown 'Rolle' prüfen`, async () => {
-        await personCreationView.comboboxOrganisationInput.searchByTitle(OrganisationLand, true);
+        await personCreationView.comboboxOrganisationInput.searchByTitle(OrganisationLand, true, 'personenkontext-workflow/**');
         await personCreationView.comboboxRolle.click();
         await expect(personCreationView.listboxRolle).toContainText(landesadminRolle);
         await expect(personCreationView.listboxRolle).not.toContainText(rolleLehr);

--- a/tests/Person.spec.ts
+++ b/tests/Person.spec.ts
@@ -427,6 +427,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
       await test.step(`Organisation 'Öffentliche Schulen Land Schleswig-Holstein' auswählen und Dropdown 'Rolle' prüfen`, async () => {
         await personCreationView.comboboxSchulstrukturknotenClear.click();
+        await waitForAPIResponse(page, 'personenkontext-workflow/**');
         await personCreationView.comboboxOrganisationInput.searchByTitle(OrganisationOeffentlicheSchule, true);
         await personCreationView.comboboxRolle.click();
         await expect(personCreationView.listboxRolle).toContainText(landesadminRolle);
@@ -440,6 +441,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
       await test.step(`Organisation 'Ersatzschulen Land Schleswig-Holstein' auswählen und Dropdown 'Rolle' prüfen`, async () => {
         await personCreationView.comboboxSchulstrukturknotenClear.click();
+        await waitForAPIResponse(page, 'personenkontext-workflow/**');
         await personCreationView.comboboxOrganisationInput.searchByTitle(OrganisationErsatzschule, true);
         await personCreationView.comboboxRolle.click();
         await expect(personCreationView.listboxRolle).toContainText(landesadminRolle);
@@ -453,6 +455,7 @@ test.describe(`Testfälle für die Administration von Personen": Umgebung: ${pro
 
       await test.step(`Organisation 'Schule' auswählen und Dropdown 'Rolle' prüfen`, async () => {
         await personCreationView.comboboxSchulstrukturknotenClear.click();
+        await waitForAPIResponse(page, 'personenkontext-workflow/**');
         await personCreationView.comboboxOrganisationInput.searchByTitle(OrganisationSchule, false);
         await personCreationView.comboboxRolle.click();
         await expect(personCreationView.listboxRolle).toContainText(rolleLehr);


### PR DESCRIPTION
### https://ticketsystem.dbildungscloud.de/browse/SPSH-2082
### person.spec.ts Zeile 429: await personCreationView.comboboxSchulstrukturknotenClear.click();
#### Das Löschen der combobox funktioniert nicht zuverlässig. Der fix ist, das nach dem Click auf das Kreuz zum leeren der combobox, auf die APIResponse gewartet wird